### PR TITLE
build vertex group

### DIFF
--- a/vertex_flow/docs/embedding_vertex.md
+++ b/vertex_flow/docs/embedding_vertex.md
@@ -1,0 +1,915 @@
+# EmbeddingVertex 文档
+
+## 概述
+
+`EmbeddingVertex` 是 VertexFlow 框架中专门用于文本嵌入（Text Embedding）的顶点类型。它继承自 `Vertex` 基类，提供了将文本转换为向量表示的功能，是构建语义搜索、相似度计算、聚类分析等应用的核心组件。
+
+## 设计理念
+
+### 1. 向量化抽象
+- **文本到向量**: 将自然语言文本转换为数值向量表示
+- **语义保持**: 保持文本的语义信息在向量空间中
+- **标准化接口**: 提供统一的嵌入生成接口
+
+### 2. 提供者无关
+- **多模型支持**: 支持 OpenAI、Sentence Transformers、本地模型等
+- **统一调用**: 通过 `TextEmbeddingProvider` 抽象不同的嵌入服务
+- **配置灵活**: 支持不同的模型参数和配置
+
+### 3. 批处理优化
+- **批量处理**: 支持多文本批量嵌入生成
+- **性能优化**: 减少 API 调用次数，提高处理效率
+- **内存管理**: 智能管理大批量数据的内存使用
+
+## 核心特性
+
+### 1. 文本嵌入生成
+- 单文本和批量文本嵌入
+- 自动文本预处理
+- 向量维度标准化
+
+### 2. 多种输入格式
+- 单个文本字符串
+- 文本列表
+- 结构化文档对象
+
+### 3. 嵌入提供者集成
+- OpenAI Embeddings API
+- Sentence Transformers 本地模型
+- 自定义嵌入服务
+
+### 4. 缓存和优化
+- 嵌入结果缓存
+- 批处理优化
+- 异步处理支持
+
+## 类设计
+
+### EmbeddingVertex
+
+```python
+class EmbeddingVertex(Vertex[T]):
+    """文本嵌入顶点，将文本转换为向量表示"""
+    
+    def __init__(
+        self,
+        id: str,
+        name: str = None,
+        params: Dict[str, Any] = None,
+        variables: List[Dict[str, Any]] = None,
+    )
+```
+
+### 参数配置
+
+`params` 字典支持以下配置项：
+
+- **embedding_provider**: `TextEmbeddingProvider` 实例，必需
+- **batch_size**: 批处理大小，默认为 100
+- **normalize**: 是否标准化向量，默认为 True
+- **cache_embeddings**: 是否缓存嵌入结果，默认为 False
+- **text_field**: 输入文本字段名，默认为 "text"
+- **output_field**: 输出向量字段名，默认为 "embedding"
+
+## 使用示例
+
+### 基本文本嵌入
+
+```python
+from vertex_flow.workflow.vertex import EmbeddingVertex
+from vertex_flow.providers.embedding import OpenAIEmbeddingProvider
+
+# 创建嵌入提供者
+embedding_provider = OpenAIEmbeddingProvider(
+    api_key="your-api-key",
+    model="text-embedding-ada-002"
+)
+
+# 创建嵌入顶点
+embedding_vertex = EmbeddingVertex(
+    id="text_embedder",
+    name="文本嵌入器",
+    params={
+        "embedding_provider": embedding_provider,
+        "normalize": True
+    }
+)
+
+# 执行单文本嵌入
+result = embedding_vertex.execute(
+    inputs={"text": "这是一个测试文本"},
+    context=workflow_context
+)
+
+print(f"嵌入维度: {len(embedding_vertex.output['embedding'])}")
+print(f"嵌入向量: {embedding_vertex.output['embedding'][:5]}...")  # 显示前5个维度
+```
+
+### 批量文本嵌入
+
+```python
+# 批量处理多个文本
+texts = [
+    "人工智能是计算机科学的一个分支",
+    "机器学习是人工智能的核心技术",
+    "深度学习是机器学习的重要方法",
+    "自然语言处理应用广泛",
+    "计算机视觉技术发展迅速"
+]
+
+batch_result = embedding_vertex.execute(
+    inputs={"texts": texts},
+    context=context
+)
+
+# 输出包含所有文本的嵌入向量
+embeddings = batch_result["embeddings"]
+print(f"处理了 {len(embeddings)} 个文本")
+print(f"每个嵌入向量维度: {len(embeddings[0])}")
+```
+
+### 文档嵌入处理
+
+```python
+# 处理结构化文档
+documents = [
+    {
+        "id": "doc1",
+        "title": "人工智能概述",
+        "content": "人工智能是模拟人类智能的技术...",
+        "category": "技术"
+    },
+    {
+        "id": "doc2",
+        "title": "机器学习基础",
+        "content": "机器学习是让计算机从数据中学习...",
+        "category": "教育"
+    }
+]
+
+# 配置文档嵌入顶点
+doc_embedding_vertex = EmbeddingVertex(
+    id="doc_embedder",
+    name="文档嵌入器",
+    params={
+        "embedding_provider": embedding_provider,
+        "text_field": "content",  # 指定要嵌入的字段
+        "batch_size": 50
+    }
+)
+
+result = doc_embedding_vertex.execute(
+    inputs={"documents": documents},
+    context=context
+)
+
+# 输出包含原文档信息和嵌入向量
+embedded_docs = result["embedded_documents"]
+for doc in embedded_docs:
+    print(f"文档 {doc['id']}: 嵌入维度 {len(doc['embedding'])}")
+```
+
+### 使用本地模型
+
+```python
+from vertex_flow.providers.embedding import SentenceTransformerProvider
+
+# 使用 Sentence Transformers 本地模型
+local_provider = SentenceTransformerProvider(
+    model_name="all-MiniLM-L6-v2",
+    device="cpu"  # 或 "cuda" 如果有 GPU
+)
+
+local_embedding_vertex = EmbeddingVertex(
+    id="local_embedder",
+    name="本地嵌入器",
+    params={
+        "embedding_provider": local_provider,
+        "batch_size": 32,
+        "normalize": True
+    }
+)
+
+# 本地模型通常处理速度更快
+result = local_embedding_vertex.execute(
+    inputs={"text": "本地模型嵌入测试"},
+    context=context
+)
+```
+
+### 多语言文本嵌入
+
+```python
+# 使用多语言模型
+multilingual_provider = SentenceTransformerProvider(
+    model_name="paraphrase-multilingual-MiniLM-L12-v2"
+)
+
+multilingual_vertex = EmbeddingVertex(
+    id="multilingual_embedder",
+    params={"embedding_provider": multilingual_provider}
+)
+
+# 处理多语言文本
+multilingual_texts = [
+    "Hello, how are you?",  # 英文
+    "你好，你好吗？",        # 中文
+    "Hola, ¿cómo estás?",   # 西班牙文
+    "Bonjour, comment allez-vous?",  # 法文
+]
+
+result = multilingual_vertex.execute(
+    inputs={"texts": multilingual_texts},
+    context=context
+)
+
+# 多语言文本在同一向量空间中
+embeddings = result["embeddings"]
+print(f"处理了 {len(embeddings)} 种语言的文本")
+```
+
+## 高级特性
+
+### 1. 嵌入缓存
+
+```python
+import hashlib
+import pickle
+import os
+
+class CachedEmbeddingVertex(EmbeddingVertex):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.cache_dir = "./embedding_cache"
+        os.makedirs(self.cache_dir, exist_ok=True)
+    
+    def _get_cache_key(self, text):
+        """生成文本的缓存键"""
+        return hashlib.md5(text.encode('utf-8')).hexdigest()
+    
+    def _load_from_cache(self, cache_key):
+        """从缓存加载嵌入"""
+        cache_file = os.path.join(self.cache_dir, f"{cache_key}.pkl")
+        if os.path.exists(cache_file):
+            with open(cache_file, 'rb') as f:
+                return pickle.load(f)
+        return None
+    
+    def _save_to_cache(self, cache_key, embedding):
+        """保存嵌入到缓存"""
+        cache_file = os.path.join(self.cache_dir, f"{cache_key}.pkl")
+        with open(cache_file, 'wb') as f:
+            pickle.dump(embedding, f)
+    
+    def execute(self, inputs, context):
+        if "text" in inputs:
+            text = inputs["text"]
+            cache_key = self._get_cache_key(text)
+            
+            # 尝试从缓存加载
+            cached_embedding = self._load_from_cache(cache_key)
+            if cached_embedding is not None:
+                print(f"使用缓存的嵌入: {cache_key}")
+                self.output = {"embedding": cached_embedding}
+                return self.output
+            
+            # 生成新嵌入
+            result = super().execute(inputs, context)
+            
+            # 保存到缓存
+            self._save_to_cache(cache_key, result["embedding"])
+            return result
+        
+        return super().execute(inputs, context)
+```
+
+### 2. 异步批处理
+
+```python
+import asyncio
+from typing import List
+
+class AsyncEmbeddingVertex(EmbeddingVertex):
+    async def execute_async(self, inputs, context):
+        """异步执行嵌入生成"""
+        if "texts" in inputs:
+            texts = inputs["texts"]
+            embeddings = await self._batch_embed_async(texts)
+            self.output = {"embeddings": embeddings}
+            return self.output
+        
+        # 单文本异步处理
+        text = inputs.get("text", "")
+        embedding = await self._embed_async(text)
+        self.output = {"embedding": embedding}
+        return self.output
+    
+    async def _batch_embed_async(self, texts: List[str]):
+        """异步批量嵌入"""
+        batch_size = self.params.get("batch_size", 100)
+        embeddings = []
+        
+        for i in range(0, len(texts), batch_size):
+            batch = texts[i:i + batch_size]
+            batch_embeddings = await self.params["embedding_provider"].embed_async(batch)
+            embeddings.extend(batch_embeddings)
+        
+        return embeddings
+    
+    async def _embed_async(self, text: str):
+        """异步单文本嵌入"""
+        return await self.params["embedding_provider"].embed_async([text])[0]
+```
+
+### 3. 相似度计算集成
+
+```python
+import numpy as np
+from sklearn.metrics.pairwise import cosine_similarity
+
+class SimilarityEmbeddingVertex(EmbeddingVertex):
+    def execute(self, inputs, context):
+        """生成嵌入并计算相似度"""
+        result = super().execute(inputs, context)
+        
+        # 如果提供了参考文本，计算相似度
+        if "reference_text" in inputs:
+            ref_result = super().execute(
+                {"text": inputs["reference_text"]}, 
+                context
+            )
+            
+            # 计算余弦相似度
+            embedding1 = np.array(result["embedding"]).reshape(1, -1)
+            embedding2 = np.array(ref_result["embedding"]).reshape(1, -1)
+            
+            similarity = cosine_similarity(embedding1, embedding2)[0][0]
+            
+            result["similarity"] = float(similarity)
+            result["reference_embedding"] = ref_result["embedding"]
+        
+        self.output = result
+        return result
+
+# 使用示例
+similarity_vertex = SimilarityEmbeddingVertex(
+    id="similarity_embedder",
+    params={"embedding_provider": embedding_provider}
+)
+
+result = similarity_vertex.execute(
+    inputs={
+        "text": "机器学习是人工智能的分支",
+        "reference_text": "人工智能包含机器学习技术"
+    },
+    context=context
+)
+
+print(f"相似度: {result['similarity']:.4f}")
+```
+
+### 4. 文本预处理集成
+
+```python
+import re
+from typing import List
+
+class PreprocessedEmbeddingVertex(EmbeddingVertex):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.preprocessors = [
+            self._clean_text,
+            self._normalize_whitespace,
+            self._remove_special_chars
+        ]
+    
+    def _clean_text(self, text: str) -> str:
+        """清理文本"""
+        # 移除 HTML 标签
+        text = re.sub(r'<[^>]+>', '', text)
+        # 移除 URL
+        text = re.sub(r'http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+', '', text)
+        return text
+    
+    def _normalize_whitespace(self, text: str) -> str:
+        """标准化空白字符"""
+        return re.sub(r'\s+', ' ', text).strip()
+    
+    def _remove_special_chars(self, text: str) -> str:
+        """移除特殊字符（可选）"""
+        # 保留中文、英文、数字和基本标点
+        return re.sub(r'[^\u4e00-\u9fa5a-zA-Z0-9\s.,!?;:]', '', text)
+    
+    def _preprocess_text(self, text: str) -> str:
+        """应用所有预处理步骤"""
+        for preprocessor in self.preprocessors:
+            text = preprocessor(text)
+        return text
+    
+    def execute(self, inputs, context):
+        # 预处理输入文本
+        if "text" in inputs:
+            inputs["text"] = self._preprocess_text(inputs["text"])
+        elif "texts" in inputs:
+            inputs["texts"] = [self._preprocess_text(text) for text in inputs["texts"]]
+        elif "documents" in inputs:
+            text_field = self.params.get("text_field", "content")
+            for doc in inputs["documents"]:
+                if text_field in doc:
+                    doc[text_field] = self._preprocess_text(doc[text_field])
+        
+        return super().execute(inputs, context)
+```
+
+## 与向量数据库集成
+
+### 与 VectorStoreVertex 配合使用
+
+```python
+from vertex_flow.workflow.vertex import VectorStoreVertex
+from vertex_flow.workflow.edge import Edge, Always
+from vertex_flow.workflow.workflow import Workflow
+
+# 创建嵌入顶点
+embedding_vertex = EmbeddingVertex(
+    id="embedder",
+    params={"embedding_provider": embedding_provider}
+)
+
+# 创建向量存储顶点
+vector_store_vertex = VectorStoreVertex(
+    id="vector_store",
+    params={
+        "vector_engine": vector_engine,
+        "collection_name": "documents"
+    },
+    variables=[
+        {
+            "source_scope": "embedder",
+            "source_var": "embedding",
+            "local_var": "vector"
+        }
+    ]
+)
+
+# 构建工作流
+workflow = Workflow()
+workflow.add_vertex(embedding_vertex)
+workflow.add_vertex(vector_store_vertex)
+workflow.add_edge(Edge(embedding_vertex, vector_store_vertex, Always()))
+
+# 执行文档存储
+workflow.execute(inputs={
+    "text": "要存储的文档内容",
+    "metadata": {"title": "文档标题", "author": "作者"}
+})
+```
+
+### 语义搜索工作流
+
+```python
+from vertex_flow.workflow.vertex import VectorQueryVertex, FunctionVertex
+
+# 查询嵌入顶点
+query_embedding_vertex = EmbeddingVertex(
+    id="query_embedder",
+    params={"embedding_provider": embedding_provider}
+)
+
+# 向量查询顶点
+vector_query_vertex = VectorQueryVertex(
+    id="vector_query",
+    params={
+        "vector_engine": vector_engine,
+        "collection_name": "documents",
+        "top_k": 5
+    },
+    variables=[
+        {
+            "source_scope": "query_embedder",
+            "source_var": "embedding",
+            "local_var": "query_vector"
+        }
+    ]
+)
+
+# 结果处理顶点
+def format_search_results(inputs):
+    results = inputs["search_results"]
+    formatted = []
+    
+    for result in results:
+        formatted.append({
+            "content": result["metadata"]["content"],
+            "score": result["score"],
+            "title": result["metadata"].get("title", "未知")
+        })
+    
+    return {"formatted_results": formatted}
+
+format_vertex = FunctionVertex(
+    id="formatter",
+    task=format_search_results,
+    variables=[
+        {
+            "source_scope": "vector_query",
+            "source_var": "results",
+            "local_var": "search_results"
+        }
+    ]
+)
+
+# 构建语义搜索工作流
+search_workflow = Workflow()
+search_workflow.add_vertex(query_embedding_vertex)
+search_workflow.add_vertex(vector_query_vertex)
+search_workflow.add_vertex(format_vertex)
+
+search_workflow.add_edge(Edge(query_embedding_vertex, vector_query_vertex, Always()))
+search_workflow.add_edge(Edge(vector_query_vertex, format_vertex, Always()))
+
+# 执行语义搜索
+search_workflow.execute(inputs={"text": "机器学习算法"})
+```
+
+## 性能优化
+
+### 1. 批处理优化
+
+```python
+class OptimizedEmbeddingVertex(EmbeddingVertex):
+    def execute(self, inputs, context):
+        """优化的批处理执行"""
+        if "texts" in inputs:
+            texts = inputs["texts"]
+            batch_size = self.params.get("batch_size", 100)
+            
+            # 智能批处理：根据文本长度调整批大小
+            avg_length = sum(len(text) for text in texts) / len(texts)
+            if avg_length > 1000:  # 长文本
+                batch_size = max(10, batch_size // 4)
+            elif avg_length < 100:  # 短文本
+                batch_size = min(500, batch_size * 2)
+            
+            embeddings = []
+            for i in range(0, len(texts), batch_size):
+                batch = texts[i:i + batch_size]
+                batch_embeddings = self.params["embedding_provider"].embed(batch)
+                embeddings.extend(batch_embeddings)
+            
+            self.output = {"embeddings": embeddings}
+            return self.output
+        
+        return super().execute(inputs, context)
+```
+
+### 2. 内存管理
+
+```python
+import gc
+from typing import Generator
+
+class MemoryEfficientEmbeddingVertex(EmbeddingVertex):
+    def execute_generator(self, inputs, context) -> Generator:
+        """生成器模式，节省内存"""
+        if "texts" in inputs:
+            texts = inputs["texts"]
+            batch_size = self.params.get("batch_size", 100)
+            
+            for i in range(0, len(texts), batch_size):
+                batch = texts[i:i + batch_size]
+                batch_embeddings = self.params["embedding_provider"].embed(batch)
+                
+                for j, embedding in enumerate(batch_embeddings):
+                    yield {
+                        "index": i + j,
+                        "text": batch[j],
+                        "embedding": embedding
+                    }
+                
+                # 强制垃圾回收
+                gc.collect()
+```
+
+### 3. 并行处理
+
+```python
+import concurrent.futures
+from typing import List
+
+class ParallelEmbeddingVertex(EmbeddingVertex):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.max_workers = self.params.get("max_workers", 4)
+    
+    def _embed_batch(self, batch: List[str]):
+        """嵌入单个批次"""
+        return self.params["embedding_provider"].embed(batch)
+    
+    def execute(self, inputs, context):
+        if "texts" in inputs:
+            texts = inputs["texts"]
+            batch_size = self.params.get("batch_size", 100)
+            
+            # 分割成批次
+            batches = [texts[i:i + batch_size] for i in range(0, len(texts), batch_size)]
+            
+            # 并行处理批次
+            embeddings = []
+            with concurrent.futures.ThreadPoolExecutor(max_workers=self.max_workers) as executor:
+                future_to_batch = {executor.submit(self._embed_batch, batch): batch for batch in batches}
+                
+                for future in concurrent.futures.as_completed(future_to_batch):
+                    batch_embeddings = future.result()
+                    embeddings.extend(batch_embeddings)
+            
+            self.output = {"embeddings": embeddings}
+            return self.output
+        
+        return super().execute(inputs, context)
+```
+
+## 错误处理和监控
+
+### 异常处理
+
+```python
+class RobustEmbeddingVertex(EmbeddingVertex):
+    def execute(self, inputs, context):
+        try:
+            return super().execute(inputs, context)
+        except Exception as e:
+            error_type = type(e).__name__
+            
+            if "rate_limit" in str(e).lower():
+                # API 限流错误
+                logging.warning(f"嵌入服务限流: {e}")
+                # 实现重试逻辑
+                return self._retry_with_backoff(inputs, context)
+            elif "timeout" in str(e).lower():
+                # 超时错误
+                logging.warning(f"嵌入服务超时: {e}")
+                return self._handle_timeout(inputs, context)
+            else:
+                # 其他错误
+                logging.error(f"嵌入生成失败 ({error_type}): {e}")
+                raise e
+    
+    def _retry_with_backoff(self, inputs, context, max_retries=3):
+        """带退避的重试机制"""
+        import time
+        
+        for attempt in range(max_retries):
+            try:
+                time.sleep(2 ** attempt)  # 指数退避
+                return super().execute(inputs, context)
+            except Exception as e:
+                if attempt == max_retries - 1:
+                    raise e
+                logging.info(f"重试 {attempt + 1}/{max_retries}")
+    
+    def _handle_timeout(self, inputs, context):
+        """处理超时情况"""
+        # 返回零向量或默认值
+        if "text" in inputs:
+            dimension = self.params.get("dimension", 1536)  # 默认维度
+            self.output = {"embedding": [0.0] * dimension}
+        elif "texts" in inputs:
+            dimension = self.params.get("dimension", 1536)
+            self.output = {"embeddings": [[0.0] * dimension] * len(inputs["texts"])}
+        
+        return self.output
+```
+
+### 性能监控
+
+```python
+import time
+from collections import defaultdict
+
+class MonitoredEmbeddingVertex(EmbeddingVertex):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.metrics = defaultdict(list)
+    
+    def execute(self, inputs, context):
+        start_time = time.time()
+        
+        # 记录输入统计
+        if "text" in inputs:
+            text_count = 1
+            total_chars = len(inputs["text"])
+        elif "texts" in inputs:
+            text_count = len(inputs["texts"])
+            total_chars = sum(len(text) for text in inputs["texts"])
+        else:
+            text_count = 0
+            total_chars = 0
+        
+        try:
+            result = super().execute(inputs, context)
+            
+            # 记录成功指标
+            execution_time = time.time() - start_time
+            self.metrics["execution_times"].append(execution_time)
+            self.metrics["text_counts"].append(text_count)
+            self.metrics["char_counts"].append(total_chars)
+            self.metrics["success_count"] += 1
+            
+            # 计算吞吐量
+            throughput = text_count / execution_time if execution_time > 0 else 0
+            self.metrics["throughput"].append(throughput)
+            
+            logging.info(f"嵌入生成完成: {text_count} 文本, {execution_time:.2f}s, {throughput:.2f} 文本/秒")
+            
+            return result
+            
+        except Exception as e:
+            self.metrics["error_count"] += 1
+            logging.error(f"嵌入生成失败: {e}")
+            raise e
+    
+    def get_performance_stats(self):
+        """获取性能统计"""
+        if not self.metrics["execution_times"]:
+            return {"message": "暂无性能数据"}
+        
+        import statistics
+        
+        return {
+            "总执行次数": len(self.metrics["execution_times"]),
+            "成功次数": self.metrics["success_count"],
+            "失败次数": self.metrics["error_count"],
+            "平均执行时间": statistics.mean(self.metrics["execution_times"]),
+            "平均吞吐量": statistics.mean(self.metrics["throughput"]),
+            "总处理文本数": sum(self.metrics["text_counts"]),
+            "总处理字符数": sum(self.metrics["char_counts"])
+        }
+```
+
+## 最佳实践
+
+### 1. 选择合适的嵌入模型
+
+```python
+# 根据应用场景选择模型
+
+# 通用英文场景
+openai_provider = OpenAIEmbeddingProvider(
+    model="text-embedding-ada-002"  # 性价比高
+)
+
+# 多语言场景
+multilingual_provider = SentenceTransformerProvider(
+    model_name="paraphrase-multilingual-MiniLM-L12-v2"
+)
+
+# 中文场景
+chinese_provider = SentenceTransformerProvider(
+    model_name="shibing624/text2vec-base-chinese"
+)
+
+# 代码场景
+code_provider = SentenceTransformerProvider(
+    model_name="microsoft/codebert-base"
+)
+
+# 科学文献场景
+scientific_provider = SentenceTransformerProvider(
+    model_name="allenai/scibert_scivocab_uncased"
+)
+```
+
+### 2. 文本预处理策略
+
+```python
+def preprocess_for_embedding(text: str, domain: str = "general") -> str:
+    """根据领域优化文本预处理"""
+    
+    # 通用预处理
+    text = text.strip()
+    text = re.sub(r'\s+', ' ', text)  # 标准化空白
+    
+    if domain == "code":
+        # 代码文本预处理
+        text = re.sub(r'#.*$', '', text, flags=re.MULTILINE)  # 移除注释
+        text = re.sub(r'\s+', ' ', text)  # 压缩空白
+    elif domain == "academic":
+        # 学术文本预处理
+        text = re.sub(r'\[[0-9,\s]+\]', '', text)  # 移除引用标记
+        text = re.sub(r'Fig\.|Figure|Table', '', text)  # 移除图表引用
+    elif domain == "web":
+        # 网页文本预处理
+        text = re.sub(r'<[^>]+>', '', text)  # 移除HTML标签
+        text = re.sub(r'http[s]?://\S+', '', text)  # 移除URL
+    
+    return text
+```
+
+### 3. 批处理优化
+
+```python
+def optimize_batch_size(texts: List[str], max_batch_size: int = 100) -> int:
+    """根据文本特征优化批处理大小"""
+    if not texts:
+        return max_batch_size
+    
+    avg_length = sum(len(text) for text in texts) / len(texts)
+    
+    if avg_length > 2000:  # 长文本
+        return min(10, max_batch_size)
+    elif avg_length > 500:  # 中等文本
+        return min(50, max_batch_size)
+    else:  # 短文本
+        return max_batch_size
+
+# 在顶点中使用
+class SmartBatchEmbeddingVertex(EmbeddingVertex):
+    def execute(self, inputs, context):
+        if "texts" in inputs:
+            texts = inputs["texts"]
+            optimal_batch_size = optimize_batch_size(texts)
+            self.params["batch_size"] = optimal_batch_size
+        
+        return super().execute(inputs, context)
+```
+
+## 常见问题
+
+### Q: 如何选择合适的嵌入维度？
+
+A: 嵌入维度通常由模型决定，但可以考虑以下因素：
+- **存储成本**: 更高维度需要更多存储空间
+- **计算效率**: 更高维度的相似度计算更慢
+- **精度要求**: 更高维度通常提供更好的语义表示
+
+### Q: 如何处理不同长度的文本？
+
+A: 大多数嵌入模型有最大长度限制：
+
+```python
+def truncate_text(text: str, max_length: int = 512) -> str:
+    """截断文本到最大长度"""
+    words = text.split()
+    if len(words) <= max_length:
+        return text
+    return ' '.join(words[:max_length])
+
+def chunk_long_text(text: str, chunk_size: int = 512, overlap: int = 50) -> List[str]:
+    """将长文本分块"""
+    words = text.split()
+    chunks = []
+    
+    for i in range(0, len(words), chunk_size - overlap):
+        chunk = ' '.join(words[i:i + chunk_size])
+        chunks.append(chunk)
+        
+        if i + chunk_size >= len(words):
+            break
+    
+    return chunks
+```
+
+### Q: 如何评估嵌入质量？
+
+A: 可以使用多种方法评估：
+
+```python
+def evaluate_embeddings(embeddings, labels=None):
+    """评估嵌入质量"""
+    from sklearn.cluster import KMeans
+    from sklearn.metrics import silhouette_score
+    import numpy as np
+    
+    embeddings = np.array(embeddings)
+    
+    # 聚类评估
+    if len(embeddings) > 10:
+        n_clusters = min(5, len(embeddings) // 2)
+        kmeans = KMeans(n_clusters=n_clusters, random_state=42)
+        cluster_labels = kmeans.fit_predict(embeddings)
+        silhouette = silhouette_score(embeddings, cluster_labels)
+        
+        print(f"聚类轮廓系数: {silhouette:.4f}")
+    
+    # 如果有标签，计算分类性能
+    if labels is not None:
+        from sklearn.linear_model import LogisticRegression
+        from sklearn.model_selection import cross_val_score
+        
+        clf = LogisticRegression(random_state=42)
+        scores = cross_val_score(clf, embeddings, labels, cv=5)
+        print(f"分类准确率: {scores.mean():.4f} ± {scores.std():.4f}")
+```
+
+## 总结
+
+`EmbeddingVertex` 是构建语义理解应用的核心组件，提供了：
+
+1. **灵活的文本嵌入**: 支持多种模型和提供者
+2. **高效的批处理**: 优化的批量处理和内存管理
+3. **丰富的集成**: 与向量数据库和搜索系统无缝集成
+4. **企业级特性**: 包括缓存、监控和错误处理
+5. **可扩展性**: 支持自定义预处理和后处理
+
+通过合理使用 `EmbeddingVertex`，可以构建强大的语义搜索、文档分析和智能推荐系统。

--- a/vertex_flow/docs/function_vertex.md
+++ b/vertex_flow/docs/function_vertex.md
@@ -1,0 +1,471 @@
+# FunctionVertex 文档
+
+## 概述
+
+`FunctionVertex` 是 VertexFlow 框架中最基础和通用的顶点类型，它继承自 `Vertex` 基类，允许用户通过传入自定义函数来实现各种业务逻辑。`FunctionVertex` 是许多其他特殊顶点类型的基础，如 `WhileVertex`、`IfElseVertex` 和 `CodeVertex`。
+
+## 设计理念
+
+### 1. 通用性
+- **函数封装**: 将任意 Python 函数封装为工作流顶点
+- **灵活输入**: 支持多种输入参数和依赖关系
+- **标准接口**: 遵循 Vertex 的标准接口规范
+
+### 2. 简单性
+- **易于使用**: 只需提供一个函数即可创建顶点
+- **自动推断**: 自动检测函数签名，智能传递参数
+- **错误处理**: 内置异常捕获和日志记录
+
+### 3. 扩展性
+- **子类基础**: 作为其他特殊顶点的基类
+- **参数化**: 支持通过参数自定义行为
+- **类型安全**: 支持泛型类型约束
+
+## 核心特性
+
+### 1. 函数执行
+- 自动检测函数签名中是否包含 `context` 参数
+- 智能传递输入参数和工作流上下文
+- 支持同步函数执行
+
+### 2. 依赖解析
+- 自动获取依赖顶点的输出
+- 合并输入参数和依赖输出
+- 支持复杂的数据流传递
+
+### 3. 子类型支持
+- 通过 `SubType` 参数自定义顶点类型
+- 支持在运行时动态确定顶点行为
+
+## 类设计
+
+### FunctionVertex
+
+```python
+class FunctionVertex(Vertex[T]):
+    """通用函数顶点，有一个输入和一个输出"""
+    
+    def __init__(
+        self,
+        id: str,
+        name: str = None,
+        task: Callable[[Dict[str, Any], WorkflowContext[T]], T] = None,
+        params: Dict[str, Any] = None,
+        variables: List[Dict[str, Any]] = None,
+    )
+```
+
+### 参数说明
+
+- **id**: 顶点的唯一标识符
+- **name**: 顶点的显示名称（可选）
+- **task**: 要执行的函数，支持两种签名：
+  - `func(inputs: Dict[str, Any]) -> T`
+  - `func(inputs: Dict[str, Any], context: WorkflowContext[T]) -> T`
+- **params**: 顶点参数字典，可包含 `SubType` 等配置
+- **variables**: 变量依赖配置列表
+
+## 使用示例
+
+### 基本使用
+
+```python
+from vertex_flow.workflow.vertex import FunctionVertex
+
+# 定义业务函数
+def add_numbers(inputs):
+    a = inputs.get("a", 0)
+    b = inputs.get("b", 0)
+    return {"sum": a + b}
+
+# 创建函数顶点
+add_vertex = FunctionVertex(
+    id="add_vertex",
+    name="加法运算",
+    task=add_numbers
+)
+
+# 执行顶点
+result = add_vertex.execute(
+    inputs={"a": 5, "b": 3},
+    context=workflow_context
+)
+print(add_vertex.output)  # {"sum": 8}
+```
+
+### 使用上下文参数
+
+```python
+def process_with_context(inputs, context):
+    """使用工作流上下文的函数"""
+    data = inputs.get("data", [])
+    
+    # 从上下文获取其他顶点的输出
+    previous_result = context.get_output("previous_vertex")
+    
+    # 处理数据
+    processed = [x * 2 for x in data]
+    
+    return {
+        "processed_data": processed,
+        "previous_result": previous_result
+    }
+
+process_vertex = FunctionVertex(
+    id="process_vertex",
+    name="数据处理",
+    task=process_with_context
+)
+```
+
+### 依赖关系配置
+
+```python
+# 创建依赖其他顶点输出的函数顶点
+dependent_vertex = FunctionVertex(
+    id="dependent_vertex",
+    name="依赖处理",
+    task=lambda inputs: {"result": inputs["value"] * 10},
+    variables=[
+        {
+            "source_scope": "source_vertex",
+            "source_var": "output_value",
+            "local_var": "value"
+        }
+    ]
+)
+```
+
+### 自定义子类型
+
+```python
+# 使用自定义子类型
+custom_vertex = FunctionVertex(
+    id="custom_vertex",
+    name="自定义处理",
+    task=custom_function,
+    params={
+        "SubType": "CUSTOM_PROCESSOR",
+        "config_param": "value"
+    }
+)
+```
+
+## 扩展类型
+
+`FunctionVertex` 作为基类，支持多种扩展类型：
+
+### IfElseVertex
+
+条件分支顶点，支持复杂的条件判断逻辑：
+
+```python
+from vertex_flow.workflow.vertex import IfElseVertex, IfCase
+
+# 定义条件案例
+cases = [
+    IfCase(
+        id="positive",
+        conditions=[
+            {"variable": "value", "operator": ">", "value": 0}
+        ]
+    ),
+    IfCase(
+        id="negative",
+        conditions=[
+            {"variable": "value", "operator": "<", "value": 0}
+        ]
+    )
+]
+
+if_else_vertex = IfElseVertex(
+    id="condition_vertex",
+    name="条件判断",
+    cases=cases
+)
+```
+
+### CodeVertex
+
+代码执行顶点，支持动态执行 Python 代码：
+
+```python
+from vertex_flow.workflow.vertex import CodeVertex
+
+code_vertex = CodeVertex(
+    id="code_vertex",
+    name="代码执行",
+    params={
+        "code": """
+result = inputs.get('x', 0) ** 2
+output = {'squared': result}
+"""
+    }
+)
+```
+
+## 函数签名检测
+
+`FunctionVertex` 会自动检测传入函数的签名，并智能决定是否传递 `context` 参数：
+
+```python
+# 不需要 context 的函数
+def simple_function(inputs):
+    return {"result": inputs["value"] * 2}
+
+# 需要 context 的函数
+def context_function(inputs, context):
+    previous = context.get_output("prev_vertex")
+    return {"result": inputs["value"] + previous["data"]}
+
+# FunctionVertex 会自动适配
+simple_vertex = FunctionVertex(id="simple", task=simple_function)
+context_vertex = FunctionVertex(id="context", task=context_function)
+```
+
+## 错误处理
+
+### 异常捕获
+
+`FunctionVertex` 内置异常处理机制：
+
+```python
+def risky_function(inputs):
+    value = inputs["value"]
+    if value == 0:
+        raise ValueError("Value cannot be zero")
+    return {"result": 100 / value}
+
+risky_vertex = FunctionVertex(
+    id="risky_vertex",
+    task=risky_function
+)
+
+try:
+    risky_vertex.execute(inputs={"value": 0})
+except ValueError as e:
+    print(f"Caught error: {e}")
+```
+
+### 日志记录
+
+执行过程中会自动记录详细日志：
+
+```python
+# 成功执行时的日志
+# INFO: Function vertex_id, output {...} after executed.
+
+# 异常时的日志
+# WARNING: Error executing vertex vertex_id: error_message
+```
+
+## 最佳实践
+
+### 1. 函数设计
+
+```python
+# 好的实践：清晰的输入输出
+def good_function(inputs):
+    """处理用户数据
+    
+    Args:
+        inputs: 包含 'user_data' 键的字典
+        
+    Returns:
+        包含 'processed_data' 键的字典
+    """
+    user_data = inputs.get("user_data", {})
+    
+    # 数据验证
+    if not user_data:
+        raise ValueError("user_data is required")
+    
+    # 业务逻辑
+    processed = process_user_data(user_data)
+    
+    return {"processed_data": processed}
+
+# 避免的做法：不清晰的接口
+def bad_function(inputs):
+    # 没有文档说明
+    # 没有输入验证
+    # 返回格式不一致
+    return inputs["x"] * 2  # 直接返回值而不是字典
+```
+
+### 2. 错误处理
+
+```python
+def robust_function(inputs):
+    """健壮的函数实现"""
+    try:
+        # 输入验证
+        required_keys = ["data", "config"]
+        for key in required_keys:
+            if key not in inputs:
+                raise ValueError(f"Missing required input: {key}")
+        
+        # 业务逻辑
+        result = process_data(inputs["data"], inputs["config"])
+        
+        return {"result": result, "status": "success"}
+        
+    except Exception as e:
+        # 记录错误但不重新抛出，返回错误状态
+        logging.error(f"Processing failed: {e}")
+        return {"result": None, "status": "error", "error": str(e)}
+```
+
+### 3. 性能优化
+
+```python
+# 对于计算密集型任务，考虑缓存
+from functools import lru_cache
+
+@lru_cache(maxsize=128)
+def expensive_calculation(value):
+    # 昂贵的计算
+    return complex_algorithm(value)
+
+def optimized_function(inputs):
+    value = inputs["value"]
+    result = expensive_calculation(value)
+    return {"result": result}
+```
+
+### 4. 类型提示
+
+```python
+from typing import Dict, Any
+
+def typed_function(inputs: Dict[str, Any]) -> Dict[str, Any]:
+    """带类型提示的函数"""
+    value: int = inputs["value"]
+    result: int = value * 2
+    return {"doubled": result}
+```
+
+## 与其他顶点的集成
+
+### 在工作流中使用
+
+```python
+from vertex_flow.workflow.workflow import Workflow
+from vertex_flow.workflow.edge import Edge, Always
+
+# 创建工作流
+workflow = Workflow()
+
+# 添加函数顶点
+workflow.add_vertex(function_vertex1)
+workflow.add_vertex(function_vertex2)
+
+# 创建边连接
+workflow.add_edge(Edge(function_vertex1, function_vertex2, Always()))
+
+# 执行工作流
+workflow.execute()
+```
+
+### 与其他顶点类型混合使用
+
+```python
+# 函数顶点 -> LLM顶点 -> 函数顶点
+preprocess_vertex = FunctionVertex(
+    id="preprocess",
+    task=preprocess_data
+)
+
+llm_vertex = LLMVertex(
+    id="llm_process",
+    params={"model": chat_model, "system": "You are a helpful assistant"}
+)
+
+postprocess_vertex = FunctionVertex(
+    id="postprocess",
+    task=postprocess_result
+)
+
+# 连接顶点
+workflow.add_edge(Edge(preprocess_vertex, llm_vertex, Always()))
+workflow.add_edge(Edge(llm_vertex, postprocess_vertex, Always()))
+```
+
+## 调试和测试
+
+### 单元测试
+
+```python
+import pytest
+from vertex_flow.workflow.vertex import FunctionVertex
+from vertex_flow.workflow.workflow import WorkflowContext
+
+def test_function_vertex():
+    """测试函数顶点"""
+    def test_task(inputs):
+        return {"result": inputs["value"] * 2}
+    
+    vertex = FunctionVertex(
+        id="test_vertex",
+        task=test_task
+    )
+    
+    context = WorkflowContext()
+    vertex.execute(inputs={"value": 5}, context=context)
+    
+    assert vertex.output == {"result": 10}
+```
+
+### 调试技巧
+
+```python
+def debug_function(inputs, context=None):
+    """带调试信息的函数"""
+    print(f"Debug: inputs = {inputs}")
+    
+    if context:
+        print(f"Debug: context outputs = {context.outputs}")
+    
+    # 业务逻辑
+    result = process_inputs(inputs)
+    
+    print(f"Debug: result = {result}")
+    return result
+
+debug_vertex = FunctionVertex(
+    id="debug_vertex",
+    task=debug_function
+)
+```
+
+## 常见问题
+
+### Q: 如何在函数中访问其他顶点的输出？
+
+A: 有两种方式：
+1. 通过 `context` 参数：`context.get_output("vertex_id")`
+2. 通过 `variables` 配置依赖关系，自动注入到 `inputs` 中
+
+### Q: 函数返回值有什么要求？
+
+A: 建议返回字典格式，便于后续顶点使用。如果返回其他类型，后续顶点需要相应处理。
+
+### Q: 如何处理函数执行失败？
+
+A: `FunctionVertex` 会自动捕获异常并重新抛出。可以在函数内部处理异常，或在工作流级别处理。
+
+### Q: 可以使用 lambda 函数吗？
+
+A: 可以，但建议用于简单逻辑。复杂逻辑建议定义具名函数，便于调试和维护。
+
+## 总结
+
+`FunctionVertex` 是 VertexFlow 框架的核心组件，提供了：
+
+1. **通用性**: 支持任意 Python 函数的封装
+2. **灵活性**: 智能的参数传递和依赖解析
+3. **扩展性**: 作为其他特殊顶点的基础
+4. **易用性**: 简单的 API 和自动化的错误处理
+5. **可靠性**: 内置的异常处理和日志记录
+
+通过合理使用 `FunctionVertex`，可以快速构建功能丰富、可维护的工作流应用。

--- a/vertex_flow/docs/llm_vertex.md
+++ b/vertex_flow/docs/llm_vertex.md
@@ -1,0 +1,850 @@
+# LLMVertex 文档
+
+## 概述
+
+`LLMVertex` 是 VertexFlow 框架中专门用于大语言模型（LLM）交互的顶点类型。它继承自 `Vertex` 基类，提供了完整的聊天对话功能，支持消息管理、工具调用、预处理和后处理等高级特性。
+
+## 设计理念
+
+### 1. 对话管理
+- **消息历史**: 自动管理对话历史和上下文
+- **角色支持**: 支持 system、user、assistant 等多种角色
+- **格式标准化**: 遵循 OpenAI 消息格式标准
+
+### 2. 模型抽象
+- **提供者无关**: 支持多种 LLM 提供者（OpenAI、Claude、本地模型等）
+- **统一接口**: 通过 `ChatProvider` 抽象统一不同模型的调用方式
+- **参数配置**: 支持温度、最大令牌数等模型参数配置
+
+### 3. 扩展能力
+- **工具调用**: 支持 Function Calling 和工具链集成
+- **预处理**: 支持输入消息的预处理和格式化
+- **后处理**: 支持输出结果的后处理和解析
+
+## 核心特性
+
+### 1. 消息管理
+- 自动构建和维护对话历史
+- 支持多轮对话上下文
+- 智能消息格式转换
+
+### 2. 模型集成
+- 支持多种 LLM 提供者
+- 统一的聊天接口
+- 灵活的参数配置
+
+### 3. 工具支持
+- Function Calling 集成
+- 自定义工具链
+- 工具结果处理
+
+### 4. 处理流水线
+- 输入预处理钩子
+- 输出后处理钩子
+- 错误处理机制
+
+## 类设计
+
+### LLMVertex
+
+```python
+class LLMVertex(Vertex[T]):
+    """大语言模型顶点，支持聊天对话"""
+    
+    def __init__(
+        self,
+        id: str,
+        name: str = None,
+        params: Dict[str, Any] = None,
+        variables: List[Dict[str, Any]] = None,
+    )
+```
+
+### 参数配置
+
+`params` 字典支持以下配置项：
+
+- **model**: `ChatProvider` 实例，必需
+- **system**: 系统提示词字符串
+- **tools**: 工具列表，支持 Function Calling
+- **preprocess**: 预处理函数
+- **postprocess**: 后处理函数
+- **temperature**: 模型温度参数
+- **max_tokens**: 最大令牌数
+- **其他模型参数**: 传递给底层模型的参数
+
+## 使用示例
+
+### 基本聊天
+
+```python
+from vertex_flow.workflow.vertex import LLMVertex
+from vertex_flow.providers.chat import OpenAIChatProvider
+
+# 创建聊天提供者
+chat_provider = OpenAIChatProvider(
+    api_key="your-api-key",
+    model="gpt-3.5-turbo"
+)
+
+# 创建 LLM 顶点
+llm_vertex = LLMVertex(
+    id="chat_vertex",
+    name="聊天助手",
+    params={
+        "model": chat_provider,
+        "system": "你是一个有用的AI助手。",
+        "temperature": 0.7,
+        "max_tokens": 1000
+    }
+)
+
+# 执行对话
+result = llm_vertex.execute(
+    inputs={"message": "你好，请介绍一下自己。"},
+    context=workflow_context
+)
+
+print(llm_vertex.output["response"])  # AI 的回复
+```
+
+### 多轮对话
+
+```python
+# 第一轮对话
+llm_vertex.execute(
+    inputs={"message": "我想学习 Python 编程。"},
+    context=context
+)
+
+# 第二轮对话（会保持上下文）
+llm_vertex.execute(
+    inputs={"message": "请推荐一些学习资源。"},
+    context=context
+)
+
+# 查看完整对话历史
+print(llm_vertex.messages)
+```
+
+### 自定义系统提示
+
+```python
+system_prompt = """
+你是一个专业的代码审查助手。请按照以下要求审查代码：
+1. 检查代码逻辑是否正确
+2. 评估代码性能和效率
+3. 提出改进建议
+4. 指出潜在的安全问题
+
+请用中文回复，格式要清晰易读。
+"""
+
+code_reviewer = LLMVertex(
+    id="code_reviewer",
+    name="代码审查助手",
+    params={
+        "model": chat_provider,
+        "system": system_prompt,
+        "temperature": 0.3  # 较低温度确保回复更准确
+    }
+)
+```
+
+### 工具调用（Function Calling）
+
+```python
+# 定义工具函数
+def get_weather(location: str) -> str:
+    """获取指定地点的天气信息"""
+    # 模拟天气 API 调用
+    return f"{location}今天晴天，温度25°C"
+
+def calculate(expression: str) -> float:
+    """计算数学表达式"""
+    try:
+        return eval(expression)
+    except:
+        return "计算错误"
+
+# 定义工具描述
+tools = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "获取天气信息",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "location": {
+                        "type": "string",
+                        "description": "地点名称"
+                    }
+                },
+                "required": ["location"]
+            }
+        }
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "calculate",
+            "description": "计算数学表达式",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "expression": {
+                        "type": "string",
+                        "description": "数学表达式"
+                    }
+                },
+                "required": ["expression"]
+            }
+        }
+    }
+]
+
+# 创建支持工具调用的 LLM 顶点
+tool_llm = LLMVertex(
+    id="tool_assistant",
+    name="工具助手",
+    params={
+        "model": chat_provider,
+        "system": "你是一个智能助手，可以使用工具来帮助用户。",
+        "tools": tools
+    }
+)
+
+# 使用工具
+result = tool_llm.execute(
+    inputs={"message": "北京今天天气怎么样？"},
+    context=context
+)
+```
+
+### 预处理和后处理
+
+```python
+def preprocess_message(inputs, context):
+    """预处理输入消息"""
+    message = inputs.get("message", "")
+    
+    # 添加时间戳
+    from datetime import datetime
+    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    
+    # 格式化消息
+    formatted_message = f"[{timestamp}] {message}"
+    
+    return {"message": formatted_message}
+
+def postprocess_response(response, context):
+    """后处理模型响应"""
+    # 提取关键信息
+    content = response.get("response", "")
+    
+    # 添加元数据
+    processed = {
+        "response": content,
+        "word_count": len(content.split()),
+        "processed_at": datetime.now().isoformat()
+    }
+    
+    return processed
+
+# 创建带处理流水线的 LLM 顶点
+processed_llm = LLMVertex(
+    id="processed_llm",
+    name="处理流水线LLM",
+    params={
+        "model": chat_provider,
+        "system": "你是一个专业助手。",
+        "preprocess": preprocess_message,
+        "postprocess": postprocess_response
+    }
+)
+```
+
+### 消息格式自定义
+
+```python
+# 使用复杂的输入格式
+complex_input = {
+    "messages": [
+        {"role": "user", "content": "你好"},
+        {"role": "assistant", "content": "你好！有什么可以帮助你的吗？"},
+        {"role": "user", "content": "请解释一下机器学习"}
+    ]
+}
+
+result = llm_vertex.execute(
+    inputs=complex_input,
+    context=context
+)
+
+# 或者使用单个消息
+simple_input = {
+    "message": "什么是深度学习？"
+}
+
+result = llm_vertex.execute(
+    inputs=simple_input,
+    context=context
+)
+```
+
+## 高级特性
+
+### 1. 流式响应
+
+```python
+# 支持流式响应的聊天提供者
+streaming_provider = OpenAIChatProvider(
+    api_key="your-api-key",
+    model="gpt-3.5-turbo",
+    stream=True
+)
+
+streaming_llm = LLMVertex(
+    id="streaming_llm",
+    params={"model": streaming_provider}
+)
+
+# 流式执行
+for chunk in streaming_llm.execute_stream(inputs={"message": "讲个故事"}):
+    print(chunk, end="", flush=True)
+```
+
+### 2. 批量处理
+
+```python
+# 批量处理多个消息
+batch_inputs = {
+    "messages": [
+        "翻译：Hello world",
+        "翻译：Good morning",
+        "翻译：Thank you"
+    ]
+}
+
+batch_llm = LLMVertex(
+    id="batch_translator",
+    params={
+        "model": chat_provider,
+        "system": "你是一个专业翻译助手，请将英文翻译成中文。"
+    }
+)
+
+results = batch_llm.execute_batch(inputs=batch_inputs)
+```
+
+### 3. 上下文管理
+
+```python
+# 自定义上下文管理
+class CustomContextManager:
+    def __init__(self, max_history=10):
+        self.max_history = max_history
+    
+    def manage_context(self, messages):
+        """管理对话上下文，保持最近的对话"""
+        if len(messages) > self.max_history:
+            # 保留系统消息和最近的对话
+            system_msgs = [msg for msg in messages if msg["role"] == "system"]
+            recent_msgs = messages[-(self.max_history-len(system_msgs)):]
+            return system_msgs + recent_msgs
+        return messages
+
+context_manager = CustomContextManager(max_history=20)
+
+managed_llm = LLMVertex(
+    id="managed_llm",
+    params={
+        "model": chat_provider,
+        "context_manager": context_manager
+    }
+)
+```
+
+## 错误处理
+
+### 异常类型
+
+```python
+try:
+    result = llm_vertex.execute(
+        inputs={"message": "测试消息"},
+        context=context
+    )
+except Exception as e:
+    if "rate_limit" in str(e).lower():
+        print("API 调用频率限制")
+        # 实现重试逻辑
+    elif "timeout" in str(e).lower():
+        print("请求超时")
+        # 处理超时
+    else:
+        print(f"其他错误: {e}")
+```
+
+### 重试机制
+
+```python
+import time
+from functools import wraps
+
+def retry_on_failure(max_retries=3, delay=1):
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            for attempt in range(max_retries):
+                try:
+                    return func(*args, **kwargs)
+                except Exception as e:
+                    if attempt == max_retries - 1:
+                        raise e
+                    print(f"重试 {attempt + 1}/{max_retries}: {e}")
+                    time.sleep(delay * (2 ** attempt))  # 指数退避
+            return None
+        return wrapper
+    return decorator
+
+# 在 LLM 顶点中使用重试
+class RobustLLMVertex(LLMVertex):
+    @retry_on_failure(max_retries=3)
+    def execute(self, inputs, context):
+        return super().execute(inputs, context)
+```
+
+## 性能优化
+
+### 1. 缓存机制
+
+```python
+from functools import lru_cache
+import hashlib
+
+class CachedLLMVertex(LLMVertex):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.cache = {}
+    
+    def _get_cache_key(self, inputs):
+        """生成缓存键"""
+        message = str(inputs)
+        return hashlib.md5(message.encode()).hexdigest()
+    
+    def execute(self, inputs, context):
+        cache_key = self._get_cache_key(inputs)
+        
+        if cache_key in self.cache:
+            print("使用缓存结果")
+            self.output = self.cache[cache_key]
+            return self.output
+        
+        result = super().execute(inputs, context)
+        self.cache[cache_key] = result
+        return result
+```
+
+### 2. 异步处理
+
+```python
+import asyncio
+from typing import AsyncGenerator
+
+class AsyncLLMVertex(LLMVertex):
+    async def execute_async(self, inputs, context):
+        """异步执行"""
+        # 异步调用模型
+        response = await self.params["model"].chat_async(
+            messages=self._build_messages(inputs, context)
+        )
+        
+        self.output = {"response": response}
+        return self.output
+    
+    async def execute_stream_async(self, inputs, context) -> AsyncGenerator[str, None]:
+        """异步流式执行"""
+        async for chunk in self.params["model"].chat_stream_async(
+            messages=self._build_messages(inputs, context)
+        ):
+            yield chunk
+```
+
+## 与工作流集成
+
+### 在工作流中使用
+
+```python
+from vertex_flow.workflow.workflow import Workflow
+from vertex_flow.workflow.edge import Edge, Always
+from vertex_flow.workflow.vertex import FunctionVertex
+
+# 创建数据预处理顶点
+def preprocess_data(inputs):
+    text = inputs["raw_text"]
+    cleaned = text.strip().lower()
+    return {"cleaned_text": cleaned}
+
+preprocess_vertex = FunctionVertex(
+    id="preprocess",
+    task=preprocess_data
+)
+
+# 创建 LLM 分析顶点
+analysis_llm = LLMVertex(
+    id="analysis",
+    params={
+        "model": chat_provider,
+        "system": "分析以下文本的情感倾向，返回正面、负面或中性。"
+    },
+    variables=[
+        {
+            "source_scope": "preprocess",
+            "source_var": "cleaned_text",
+            "local_var": "text"
+        }
+    ]
+)
+
+# 创建结果处理顶点
+def process_result(inputs):
+    sentiment = inputs["analysis_result"]
+    confidence = calculate_confidence(sentiment)
+    return {
+        "sentiment": sentiment,
+        "confidence": confidence
+    }
+
+result_vertex = FunctionVertex(
+    id="result_processor",
+    task=process_result,
+    variables=[
+        {
+            "source_scope": "analysis",
+            "source_var": "response",
+            "local_var": "analysis_result"
+        }
+    ]
+)
+
+# 构建工作流
+workflow = Workflow()
+workflow.add_vertex(preprocess_vertex)
+workflow.add_vertex(analysis_llm)
+workflow.add_vertex(result_vertex)
+
+workflow.add_edge(Edge(preprocess_vertex, analysis_llm, Always()))
+workflow.add_edge(Edge(analysis_llm, result_vertex, Always()))
+
+# 执行工作流
+workflow.execute(inputs={"raw_text": "这个产品真的很棒！"})
+```
+
+### 多 LLM 协作
+
+```python
+# 创建多个专门的 LLM 顶点
+summarizer = LLMVertex(
+    id="summarizer",
+    params={
+        "model": chat_provider,
+        "system": "你是一个专业的文本摘要助手，请提供简洁准确的摘要。"
+    }
+)
+
+translator = LLMVertex(
+    id="translator",
+    params={
+        "model": chat_provider,
+        "system": "你是一个专业翻译助手，请将中文翻译成英文。"
+    },
+    variables=[
+        {
+            "source_scope": "summarizer",
+            "source_var": "response",
+            "local_var": "text_to_translate"
+        }
+    ]
+)
+
+reviewer = LLMVertex(
+    id="reviewer",
+    params={
+        "model": chat_provider,
+        "system": "你是一个质量审查员，请评估翻译质量并提出改进建议。"
+    },
+    variables=[
+        {
+            "source_scope": "translator",
+            "source_var": "response",
+            "local_var": "translation"
+        }
+    ]
+)
+
+# 连接 LLM 顶点
+workflow.add_edge(Edge(summarizer, translator, Always()))
+workflow.add_edge(Edge(translator, reviewer, Always()))
+```
+
+## 调试和监控
+
+### 日志记录
+
+```python
+import logging
+
+# 配置详细日志
+logging.basicConfig(level=logging.DEBUG)
+
+# LLM 顶点会自动记录详细信息
+llm_vertex = LLMVertex(
+    id="debug_llm",
+    params={
+        "model": chat_provider,
+        "system": "测试系统",
+        "debug": True  # 启用调试模式
+    }
+)
+
+# 执行时会看到详细日志
+# DEBUG: Building messages for LLM vertex: debug_llm
+# DEBUG: Input messages: [...]
+# DEBUG: Model response: {...}
+# INFO: LLM vertex debug_llm executed successfully
+```
+
+### 性能监控
+
+```python
+import time
+from contextlib import contextmanager
+
+@contextmanager
+def timer(name):
+    start = time.time()
+    yield
+    end = time.time()
+    print(f"{name} 耗时: {end - start:.2f} 秒")
+
+class MonitoredLLMVertex(LLMVertex):
+    def execute(self, inputs, context):
+        with timer(f"LLM顶点 {self.id}"):
+            return super().execute(inputs, context)
+```
+
+### 成本跟踪
+
+```python
+class CostTrackingLLMVertex(LLMVertex):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.total_tokens = 0
+        self.total_cost = 0.0
+    
+    def execute(self, inputs, context):
+        result = super().execute(inputs, context)
+        
+        # 假设模型返回了 token 使用信息
+        if "usage" in result:
+            tokens = result["usage"]["total_tokens"]
+            cost = self._calculate_cost(tokens)
+            
+            self.total_tokens += tokens
+            self.total_cost += cost
+            
+            print(f"本次调用: {tokens} tokens, ${cost:.4f}")
+            print(f"累计: {self.total_tokens} tokens, ${self.total_cost:.4f}")
+        
+        return result
+    
+    def _calculate_cost(self, tokens):
+        # 根据模型定价计算成本
+        price_per_1k_tokens = 0.002  # 示例价格
+        return (tokens / 1000) * price_per_1k_tokens
+```
+
+## 最佳实践
+
+### 1. 系统提示设计
+
+```python
+# 好的系统提示
+good_system_prompt = """
+你是一个专业的代码审查助手。请按照以下标准审查代码：
+
+## 审查要点
+1. **功能正确性**: 代码是否实现了预期功能
+2. **性能效率**: 是否存在性能瓶颈
+3. **安全性**: 是否存在安全漏洞
+4. **可维护性**: 代码是否易于理解和维护
+5. **最佳实践**: 是否遵循语言和框架的最佳实践
+
+## 输出格式
+请使用以下格式输出审查结果：
+
+### 总体评分
+[1-10分]
+
+### 主要问题
+- 问题1: 描述和建议
+- 问题2: 描述和建议
+
+### 改进建议
+- 建议1
+- 建议2
+
+请用中文回复，保持专业和建设性的语调。
+"""
+
+# 避免的做法
+bad_system_prompt = "你是助手，帮我审查代码。"  # 太简单，缺乏具体指导
+```
+
+### 2. 错误恢复
+
+```python
+class ResilientLLMVertex(LLMVertex):
+    def execute(self, inputs, context):
+        try:
+            return super().execute(inputs, context)
+        except Exception as e:
+            # 记录错误
+            logging.error(f"LLM执行失败: {e}")
+            
+            # 返回默认响应
+            self.output = {
+                "response": "抱歉，我现在无法处理您的请求，请稍后再试。",
+                "error": True,
+                "error_message": str(e)
+            }
+            return self.output
+```
+
+### 3. 输入验证
+
+```python
+def validate_llm_inputs(inputs):
+    """验证 LLM 输入"""
+    if not inputs:
+        raise ValueError("输入不能为空")
+    
+    if "message" not in inputs and "messages" not in inputs:
+        raise ValueError("必须提供 'message' 或 'messages' 字段")
+    
+    if "message" in inputs:
+        message = inputs["message"]
+        if not isinstance(message, str) or not message.strip():
+            raise ValueError("消息必须是非空字符串")
+        
+        if len(message) > 10000:  # 限制消息长度
+            raise ValueError("消息长度不能超过10000字符")
+    
+    return True
+
+class ValidatedLLMVertex(LLMVertex):
+    def execute(self, inputs, context):
+        validate_llm_inputs(inputs)
+        return super().execute(inputs, context)
+```
+
+## 常见问题
+
+### Q: 如何处理 API 调用限制？
+
+A: 实现重试机制和速率限制：
+
+```python
+import time
+from threading import Lock
+
+class RateLimitedLLMVertex(LLMVertex):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.last_call_time = 0
+        self.min_interval = 1.0  # 最小调用间隔（秒）
+        self.lock = Lock()
+    
+    def execute(self, inputs, context):
+        with self.lock:
+            current_time = time.time()
+            time_since_last_call = current_time - self.last_call_time
+            
+            if time_since_last_call < self.min_interval:
+                sleep_time = self.min_interval - time_since_last_call
+                time.sleep(sleep_time)
+            
+            result = super().execute(inputs, context)
+            self.last_call_time = time.time()
+            return result
+```
+
+### Q: 如何管理长对话的上下文？
+
+A: 实现智能上下文截断：
+
+```python
+def smart_context_management(messages, max_tokens=4000):
+    """智能管理对话上下文"""
+    # 估算 token 数量（简化版本）
+    def estimate_tokens(text):
+        return len(text.split()) * 1.3
+    
+    total_tokens = sum(estimate_tokens(msg["content"]) for msg in messages)
+    
+    if total_tokens <= max_tokens:
+        return messages
+    
+    # 保留系统消息和最近的对话
+    system_messages = [msg for msg in messages if msg["role"] == "system"]
+    other_messages = [msg for msg in messages if msg["role"] != "system"]
+    
+    # 从最新消息开始保留
+    kept_messages = []
+    current_tokens = sum(estimate_tokens(msg["content"]) for msg in system_messages)
+    
+    for msg in reversed(other_messages):
+        msg_tokens = estimate_tokens(msg["content"])
+        if current_tokens + msg_tokens <= max_tokens:
+            kept_messages.insert(0, msg)
+            current_tokens += msg_tokens
+        else:
+            break
+    
+    return system_messages + kept_messages
+```
+
+### Q: 如何实现流式响应？
+
+A: 使用生成器和异步处理：
+
+```python
+class StreamingLLMVertex(LLMVertex):
+    def execute_stream(self, inputs, context):
+        """流式执行"""
+        messages = self._build_messages(inputs, context)
+        
+        response_chunks = []
+        for chunk in self.params["model"].chat_stream(messages):
+            response_chunks.append(chunk)
+            yield chunk
+        
+        # 保存完整响应
+        full_response = "".join(response_chunks)
+        self.output = {"response": full_response}
+```
+
+## 总结
+
+`LLMVertex` 是 VertexFlow 框架中功能最丰富的顶点类型之一，提供了：
+
+1. **完整的对话管理**: 支持多轮对话和上下文维护
+2. **灵活的模型集成**: 支持多种 LLM 提供者和配置
+3. **强大的工具支持**: 集成 Function Calling 和自定义工具
+4. **可扩展的处理流水线**: 支持预处理和后处理钩子
+5. **企业级特性**: 包括错误处理、性能监控和成本跟踪
+
+通过合理使用 `LLMVertex`，可以构建智能、可靠的 AI 应用和工作流。

--- a/vertex_flow/docs/vector_vertex.md
+++ b/vertex_flow/docs/vector_vertex.md
@@ -1,0 +1,1133 @@
+# VectorVertex 文档
+
+## 概述
+
+`VectorVertex` 是 VertexFlow 框架中专门用于向量操作的顶点类型系列。它包含一个抽象基类 `VectorVertex` 和两个具体实现：`VectorStoreVertex`（向量存储）和 `VectorQueryVertex`（向量查询）。这些顶点类型是构建向量数据库应用、语义搜索和相似度匹配系统的核心组件。
+
+## 设计理念
+
+### 1. 向量数据管理
+- **统一接口**: 提供统一的向量存储和查询接口
+- **引擎抽象**: 通过 `VectorEngine` 抽象不同的向量数据库
+- **高效操作**: 优化向量的存储、索引和检索性能
+
+### 2. 可扩展架构
+- **插件化设计**: 支持多种向量数据库后端
+- **灵活配置**: 支持不同的索引类型和相似度度量
+- **批量操作**: 支持批量存储和查询优化
+
+### 3. 语义搜索支持
+- **多模态支持**: 支持文本、图像等多种数据类型的向量化
+- **元数据管理**: 支持丰富的元数据存储和过滤
+- **相似度计算**: 支持多种相似度度量方法
+
+## 核心特性
+
+### 1. 向量存储（VectorStoreVertex）
+- 高效的向量数据存储
+- 元数据关联和管理
+- 批量插入优化
+- 索引构建和维护
+
+### 2. 向量查询（VectorQueryVertex）
+- 快速相似度搜索
+- Top-K 结果检索
+- 元数据过滤
+- 混合搜索支持
+
+### 3. 向量引擎集成
+- Faiss 本地向量库
+- Pinecone 云向量数据库
+- Weaviate 向量搜索引擎
+- Chroma 嵌入式向量数据库
+
+## 类设计
+
+### VectorVertex（抽象基类）
+
+```python
+class VectorVertex(Vertex[T]):
+    """向量操作的抽象基类"""
+    
+    def __init__(
+        self,
+        id: str,
+        name: str = None,
+        params: Dict[str, Any] = None,
+        variables: List[Dict[str, Any]] = None,
+    )
+```
+
+### VectorStoreVertex（向量存储）
+
+```python
+class VectorStoreVertex(VectorVertex[T]):
+    """向量存储顶点，用于存储向量数据"""
+    
+    def execute(self, inputs: Dict[str, Any], context: WorkflowContext[T]) -> Dict[str, Any]:
+        """执行向量存储操作"""
+```
+
+### VectorQueryVertex（向量查询）
+
+```python
+class VectorQueryVertex(VectorVertex[T]):
+    """向量查询顶点，用于查询相似向量"""
+    
+    def execute(self, inputs: Dict[str, Any], context: WorkflowContext[T]) -> Dict[str, Any]:
+        """执行向量查询操作"""
+```
+
+### 参数配置
+
+#### VectorStoreVertex 参数
+- **vector_engine**: `VectorEngine` 实例，必需
+- **collection_name**: 集合名称，默认为 "default"
+- **batch_size**: 批处理大小，默认为 100
+- **create_index**: 是否创建索引，默认为 True
+- **index_type**: 索引类型（如 "IVF", "HNSW"）
+- **metric**: 相似度度量（如 "cosine", "euclidean"）
+
+#### VectorQueryVertex 参数
+- **vector_engine**: `VectorEngine` 实例，必需
+- **collection_name**: 集合名称，默认为 "default"
+- **top_k**: 返回结果数量，默认为 10
+- **threshold**: 相似度阈值，默认为 0.0
+- **include_metadata**: 是否包含元数据，默认为 True
+- **filter**: 元数据过滤条件
+
+## 使用示例
+
+### 基本向量存储
+
+```python
+from vertex_flow.workflow.vertex import VectorStoreVertex
+from vertex_flow.engines.vector import FaissVectorEngine
+
+# 创建向量引擎
+vector_engine = FaissVectorEngine(
+    dimension=1536,  # 向量维度
+    index_type="IVF",  # 索引类型
+    metric="cosine"  # 相似度度量
+)
+
+# 创建向量存储顶点
+vector_store = VectorStoreVertex(
+    id="document_store",
+    name="文档向量存储",
+    params={
+        "vector_engine": vector_engine,
+        "collection_name": "documents",
+        "batch_size": 50
+    }
+)
+
+# 存储单个向量
+result = vector_store.execute(
+    inputs={
+        "vector": [0.1, 0.2, 0.3, ...],  # 1536维向量
+        "metadata": {
+            "title": "文档标题",
+            "content": "文档内容",
+            "author": "作者",
+            "timestamp": "2024-01-01"
+        },
+        "id": "doc_001"
+    },
+    context=workflow_context
+)
+
+print(f"存储结果: {vector_store.output}")
+```
+
+### 批量向量存储
+
+```python
+# 批量存储多个向量
+vectors_data = [
+    {
+        "vector": [0.1, 0.2, 0.3, ...],
+        "metadata": {"title": "文档1", "category": "技术"},
+        "id": "doc_001"
+    },
+    {
+        "vector": [0.4, 0.5, 0.6, ...],
+        "metadata": {"title": "文档2", "category": "科学"},
+        "id": "doc_002"
+    },
+    {
+        "vector": [0.7, 0.8, 0.9, ...],
+        "metadata": {"title": "文档3", "category": "技术"},
+        "id": "doc_003"
+    }
+]
+
+batch_result = vector_store.execute(
+    inputs={"vectors": vectors_data},
+    context=context
+)
+
+print(f"批量存储了 {len(vectors_data)} 个向量")
+```
+
+### 向量查询
+
+```python
+from vertex_flow.workflow.vertex import VectorQueryVertex
+
+# 创建向量查询顶点
+vector_query = VectorQueryVertex(
+    id="document_search",
+    name="文档向量搜索",
+    params={
+        "vector_engine": vector_engine,
+        "collection_name": "documents",
+        "top_k": 5,
+        "threshold": 0.7,
+        "include_metadata": True
+    }
+)
+
+# 执行相似度搜索
+search_result = vector_query.execute(
+    inputs={
+        "query_vector": [0.15, 0.25, 0.35, ...],  # 查询向量
+    },
+    context=context
+)
+
+# 处理搜索结果
+results = search_result["results"]
+for i, result in enumerate(results):
+    print(f"结果 {i+1}:")
+    print(f"  相似度: {result['score']:.4f}")
+    print(f"  标题: {result['metadata']['title']}")
+    print(f"  类别: {result['metadata']['category']}")
+    print()
+```
+
+### 带过滤条件的查询
+
+```python
+# 使用元数据过滤
+filtered_query = VectorQueryVertex(
+    id="filtered_search",
+    params={
+        "vector_engine": vector_engine,
+        "collection_name": "documents",
+        "top_k": 10,
+        "filter": {
+            "category": "技术",  # 只搜索技术类文档
+            "timestamp": {"$gte": "2024-01-01"}  # 2024年以后的文档
+        }
+    }
+)
+
+filtered_result = filtered_query.execute(
+    inputs={"query_vector": query_vector},
+    context=context
+)
+```
+
+## 与嵌入顶点集成
+
+### 完整的文档存储工作流
+
+```python
+from vertex_flow.workflow.vertex import EmbeddingVertex, FunctionVertex
+from vertex_flow.workflow.edge import Edge, Always
+from vertex_flow.workflow.workflow import Workflow
+
+# 1. 文本预处理顶点
+def preprocess_document(inputs):
+    doc = inputs["document"]
+    
+    # 清理和格式化文本
+    cleaned_content = doc["content"].strip().replace("\n", " ")
+    
+    return {
+        "text": cleaned_content,
+        "metadata": {
+            "title": doc["title"],
+            "author": doc.get("author", "未知"),
+            "category": doc.get("category", "其他"),
+            "length": len(cleaned_content)
+        },
+        "doc_id": doc["id"]
+    }
+
+preprocess_vertex = FunctionVertex(
+    id="preprocessor",
+    task=preprocess_document
+)
+
+# 2. 文本嵌入顶点
+embedding_vertex = EmbeddingVertex(
+    id="embedder",
+    params={"embedding_provider": embedding_provider},
+    variables=[
+        {
+            "source_scope": "preprocessor",
+            "source_var": "text",
+            "local_var": "text"
+        }
+    ]
+)
+
+# 3. 向量存储顶点
+vector_store_vertex = VectorStoreVertex(
+    id="vector_store",
+    params={
+        "vector_engine": vector_engine,
+        "collection_name": "documents"
+    },
+    variables=[
+        {
+            "source_scope": "embedder",
+            "source_var": "embedding",
+            "local_var": "vector"
+        },
+        {
+            "source_scope": "preprocessor",
+            "source_var": "metadata",
+            "local_var": "metadata"
+        },
+        {
+            "source_scope": "preprocessor",
+            "source_var": "doc_id",
+            "local_var": "id"
+        }
+    ]
+)
+
+# 构建存储工作流
+storage_workflow = Workflow()
+storage_workflow.add_vertex(preprocess_vertex)
+storage_workflow.add_vertex(embedding_vertex)
+storage_workflow.add_vertex(vector_store_vertex)
+
+storage_workflow.add_edge(Edge(preprocess_vertex, embedding_vertex, Always()))
+storage_workflow.add_edge(Edge(embedding_vertex, vector_store_vertex, Always()))
+
+# 执行文档存储
+document = {
+    "id": "tech_001",
+    "title": "机器学习基础",
+    "content": "机器学习是人工智能的一个重要分支...",
+    "author": "张三",
+    "category": "技术"
+}
+
+storage_workflow.execute(inputs={"document": document})
+```
+
+### 语义搜索工作流
+
+```python
+# 查询嵌入顶点
+query_embedding_vertex = EmbeddingVertex(
+    id="query_embedder",
+    params={"embedding_provider": embedding_provider}
+)
+
+# 向量查询顶点
+vector_query_vertex = VectorQueryVertex(
+    id="vector_searcher",
+    params={
+        "vector_engine": vector_engine,
+        "collection_name": "documents",
+        "top_k": 5
+    },
+    variables=[
+        {
+            "source_scope": "query_embedder",
+            "source_var": "embedding",
+            "local_var": "query_vector"
+        }
+    ]
+)
+
+# 结果后处理顶点
+def format_search_results(inputs):
+    results = inputs["search_results"]
+    
+    formatted_results = []
+    for result in results:
+        formatted_results.append({
+            "title": result["metadata"]["title"],
+            "author": result["metadata"]["author"],
+            "category": result["metadata"]["category"],
+            "similarity": result["score"],
+            "relevance": "高" if result["score"] > 0.8 else "中" if result["score"] > 0.6 else "低"
+        })
+    
+    return {"formatted_results": formatted_results}
+
+format_vertex = FunctionVertex(
+    id="formatter",
+    task=format_search_results,
+    variables=[
+        {
+            "source_scope": "vector_searcher",
+            "source_var": "results",
+            "local_var": "search_results"
+        }
+    ]
+)
+
+# 构建搜索工作流
+search_workflow = Workflow()
+search_workflow.add_vertex(query_embedding_vertex)
+search_workflow.add_vertex(vector_query_vertex)
+search_workflow.add_vertex(format_vertex)
+
+search_workflow.add_edge(Edge(query_embedding_vertex, vector_query_vertex, Always()))
+search_workflow.add_edge(Edge(vector_query_vertex, format_vertex, Always()))
+
+# 执行语义搜索
+search_workflow.execute(inputs={"text": "深度学习算法"})
+
+# 获取格式化的搜索结果
+results = format_vertex.output["formatted_results"]
+for result in results:
+    print(f"标题: {result['title']}")
+    print(f"作者: {result['author']}")
+    print(f"相似度: {result['similarity']:.4f} ({result['relevance']})")
+    print()
+```
+
+## 高级特性
+
+### 1. 混合搜索
+
+```python
+class HybridSearchVertex(VectorQueryVertex):
+    """混合搜索：结合向量搜索和关键词搜索"""
+    
+    def execute(self, inputs, context):
+        # 向量搜索
+        vector_results = super().execute(inputs, context)
+        
+        # 关键词搜索（如果提供了查询文本）
+        if "query_text" in inputs:
+            keyword_results = self._keyword_search(
+                inputs["query_text"],
+                inputs.get("keyword_top_k", 10)
+            )
+            
+            # 合并和重排序结果
+            combined_results = self._merge_results(
+                vector_results["results"],
+                keyword_results,
+                alpha=inputs.get("alpha", 0.7)  # 向量搜索权重
+            )
+            
+            self.output = {"results": combined_results}
+        
+        return self.output
+    
+    def _keyword_search(self, query_text, top_k):
+        """关键词搜索实现"""
+        # 这里可以集成 Elasticsearch 或其他全文搜索引擎
+        # 简化示例
+        return []
+    
+    def _merge_results(self, vector_results, keyword_results, alpha):
+        """合并向量搜索和关键词搜索结果"""
+        # 实现结果合并和重排序逻辑
+        # alpha * vector_score + (1-alpha) * keyword_score
+        return vector_results  # 简化返回
+```
+
+### 2. 增量索引更新
+
+```python
+class IncrementalVectorStoreVertex(VectorStoreVertex):
+    """支持增量更新的向量存储"""
+    
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.update_buffer = []
+        self.buffer_size = self.params.get("buffer_size", 100)
+    
+    def execute(self, inputs, context):
+        if "vector" in inputs:
+            # 单个向量更新
+            self.update_buffer.append({
+                "vector": inputs["vector"],
+                "metadata": inputs.get("metadata", {}),
+                "id": inputs.get("id")
+            })
+        elif "vectors" in inputs:
+            # 批量向量更新
+            self.update_buffer.extend(inputs["vectors"])
+        
+        # 检查是否需要刷新缓冲区
+        if len(self.update_buffer) >= self.buffer_size:
+            self._flush_buffer()
+        
+        return super().execute(inputs, context)
+    
+    def _flush_buffer(self):
+        """刷新缓冲区到向量引擎"""
+        if self.update_buffer:
+            # 批量更新向量引擎
+            self.params["vector_engine"].batch_upsert(
+                collection_name=self.params["collection_name"],
+                vectors=self.update_buffer
+            )
+            
+            print(f"刷新了 {len(self.update_buffer)} 个向量到索引")
+            self.update_buffer.clear()
+    
+    def finalize(self):
+        """最终化：刷新剩余缓冲区"""
+        self._flush_buffer()
+```
+
+### 3. 多集合管理
+
+```python
+class MultiCollectionVectorVertex(VectorVertex):
+    """多集合向量管理"""
+    
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.collections = self.params.get("collections", {})
+    
+    def create_collection(self, name, dimension, index_type="IVF"):
+        """创建新集合"""
+        self.params["vector_engine"].create_collection(
+            name=name,
+            dimension=dimension,
+            index_type=index_type
+        )
+        self.collections[name] = {
+            "dimension": dimension,
+            "index_type": index_type,
+            "created_at": datetime.now().isoformat()
+        }
+    
+    def list_collections(self):
+        """列出所有集合"""
+        return list(self.collections.keys())
+    
+    def get_collection_stats(self, collection_name):
+        """获取集合统计信息"""
+        return self.params["vector_engine"].get_collection_stats(collection_name)
+    
+    def delete_collection(self, collection_name):
+        """删除集合"""
+        self.params["vector_engine"].delete_collection(collection_name)
+        if collection_name in self.collections:
+            del self.collections[collection_name]
+```
+
+### 4. 向量索引优化
+
+```python
+class OptimizedVectorStoreVertex(VectorStoreVertex):
+    """优化的向量存储"""
+    
+    def execute(self, inputs, context):
+        # 执行基本存储
+        result = super().execute(inputs, context)
+        
+        # 检查是否需要重建索引
+        if self._should_rebuild_index():
+            self._rebuild_index()
+        
+        return result
+    
+    def _should_rebuild_index(self):
+        """判断是否需要重建索引"""
+        stats = self.params["vector_engine"].get_collection_stats(
+            self.params["collection_name"]
+        )
+        
+        # 如果向量数量增长超过阈值，重建索引
+        threshold = self.params.get("rebuild_threshold", 10000)
+        return stats.get("vector_count", 0) % threshold == 0
+    
+    def _rebuild_index(self):
+        """重建索引以优化性能"""
+        print("开始重建向量索引...")
+        
+        self.params["vector_engine"].rebuild_index(
+            collection_name=self.params["collection_name"],
+            index_type=self.params.get("index_type", "IVF"),
+            metric=self.params.get("metric", "cosine")
+        )
+        
+        print("向量索引重建完成")
+```
+
+## 向量引擎集成
+
+### Faiss 本地引擎
+
+```python
+from vertex_flow.engines.vector import FaissVectorEngine
+
+# 创建 Faiss 引擎
+faiss_engine = FaissVectorEngine(
+    dimension=1536,
+    index_type="IVF",  # 或 "HNSW", "Flat"
+    metric="cosine",   # 或 "euclidean", "inner_product"
+    nlist=100,         # IVF 参数
+    nprobe=10          # 查询参数
+)
+
+# 使用 Faiss 引擎的向量顶点
+faiss_store = VectorStoreVertex(
+    id="faiss_store",
+    params={
+        "vector_engine": faiss_engine,
+        "collection_name": "faiss_collection"
+    }
+)
+```
+
+### Pinecone 云引擎
+
+```python
+from vertex_flow.engines.vector import PineconeVectorEngine
+
+# 创建 Pinecone 引擎
+pinecone_engine = PineconeVectorEngine(
+    api_key="your-pinecone-api-key",
+    environment="us-west1-gcp",
+    index_name="your-index-name"
+)
+
+# 使用 Pinecone 引擎的向量顶点
+pinecone_store = VectorStoreVertex(
+    id="pinecone_store",
+    params={
+        "vector_engine": pinecone_engine,
+        "collection_name": "pinecone_collection"
+    }
+)
+```
+
+### Weaviate 引擎
+
+```python
+from vertex_flow.engines.vector import WeaviateVectorEngine
+
+# 创建 Weaviate 引擎
+weaviate_engine = WeaviateVectorEngine(
+    url="http://localhost:8080",
+    api_key="your-weaviate-api-key",  # 可选
+    additional_headers={}  # 可选
+)
+
+# 使用 Weaviate 引擎的向量顶点
+weaviate_store = VectorStoreVertex(
+    id="weaviate_store",
+    params={
+        "vector_engine": weaviate_engine,
+        "collection_name": "Document",  # Weaviate 类名
+        "schema": {
+            "class": "Document",
+            "properties": [
+                {"name": "title", "dataType": ["string"]},
+                {"name": "content", "dataType": ["text"]},
+                {"name": "category", "dataType": ["string"]}
+            ]
+        }
+    }
+)
+```
+
+## 性能优化
+
+### 1. 批处理优化
+
+```python
+class BatchOptimizedVectorStore(VectorStoreVertex):
+    """批处理优化的向量存储"""
+    
+    def execute(self, inputs, context):
+        if "vectors" in inputs:
+            vectors = inputs["vectors"]
+            batch_size = self.params.get("batch_size", 100)
+            
+            # 根据向量维度动态调整批大小
+            if vectors and len(vectors[0]["vector"]) > 1000:
+                batch_size = max(10, batch_size // 2)
+            
+            # 分批处理
+            results = []
+            for i in range(0, len(vectors), batch_size):
+                batch = vectors[i:i + batch_size]
+                batch_result = self._process_batch(batch)
+                results.extend(batch_result)
+            
+            self.output = {"stored_count": len(results), "results": results}
+            return self.output
+        
+        return super().execute(inputs, context)
+    
+    def _process_batch(self, batch):
+        """处理单个批次"""
+        return self.params["vector_engine"].batch_insert(
+            collection_name=self.params["collection_name"],
+            vectors=[item["vector"] for item in batch],
+            metadatas=[item.get("metadata", {}) for item in batch],
+            ids=[item.get("id") for item in batch]
+        )
+```
+
+### 2. 查询优化
+
+```python
+class OptimizedVectorQuery(VectorQueryVertex):
+    """优化的向量查询"""
+    
+    def execute(self, inputs, context):
+        # 查询预处理
+        query_vector = inputs["query_vector"]
+        
+        # 向量标准化
+        if self.params.get("normalize_query", True):
+            query_vector = self._normalize_vector(query_vector)
+        
+        # 动态调整 top_k
+        top_k = self._adjust_top_k(inputs.get("top_k", self.params.get("top_k", 10)))
+        
+        # 执行查询
+        results = self.params["vector_engine"].query(
+            collection_name=self.params["collection_name"],
+            query_vector=query_vector,
+            top_k=top_k,
+            filter=inputs.get("filter", self.params.get("filter")),
+            include_metadata=self.params.get("include_metadata", True)
+        )
+        
+        # 后处理结果
+        processed_results = self._postprocess_results(results)
+        
+        self.output = {"results": processed_results}
+        return self.output
+    
+    def _normalize_vector(self, vector):
+        """标准化向量"""
+        import numpy as np
+        vector = np.array(vector)
+        norm = np.linalg.norm(vector)
+        return (vector / norm).tolist() if norm > 0 else vector.tolist()
+    
+    def _adjust_top_k(self, requested_top_k):
+        """动态调整 top_k"""
+        # 根据集合大小调整
+        stats = self.params["vector_engine"].get_collection_stats(
+            self.params["collection_name"]
+        )
+        
+        max_vectors = stats.get("vector_count", float('inf'))
+        return min(requested_top_k, max_vectors)
+    
+    def _postprocess_results(self, results):
+        """后处理查询结果"""
+        threshold = self.params.get("threshold", 0.0)
+        
+        # 过滤低相似度结果
+        filtered_results = [
+            result for result in results 
+            if result["score"] >= threshold
+        ]
+        
+        # 添加相似度等级
+        for result in filtered_results:
+            score = result["score"]
+            if score >= 0.9:
+                result["similarity_level"] = "极高"
+            elif score >= 0.8:
+                result["similarity_level"] = "高"
+            elif score >= 0.6:
+                result["similarity_level"] = "中"
+            else:
+                result["similarity_level"] = "低"
+        
+        return filtered_results
+```
+
+### 3. 内存管理
+
+```python
+import gc
+from typing import Generator
+
+class MemoryEfficientVectorStore(VectorStoreVertex):
+    """内存高效的向量存储"""
+    
+    def execute_stream(self, inputs, context) -> Generator:
+        """流式处理大量向量"""
+        if "vectors" in inputs:
+            vectors = inputs["vectors"]
+            batch_size = self.params.get("batch_size", 100)
+            
+            for i in range(0, len(vectors), batch_size):
+                batch = vectors[i:i + batch_size]
+                
+                # 处理批次
+                batch_result = self._process_batch(batch)
+                
+                # 生成结果
+                for j, result in enumerate(batch_result):
+                    yield {
+                        "index": i + j,
+                        "id": batch[j].get("id"),
+                        "status": "stored",
+                        "result": result
+                    }
+                
+                # 强制垃圾回收
+                gc.collect()
+    
+    def _process_batch(self, batch):
+        """处理单个批次"""
+        return self.params["vector_engine"].batch_insert(
+            collection_name=self.params["collection_name"],
+            vectors=[item["vector"] for item in batch],
+            metadatas=[item.get("metadata", {}) for item in batch],
+            ids=[item.get("id") for item in batch]
+        )
+```
+
+## 错误处理和监控
+
+### 异常处理
+
+```python
+class RobustVectorVertex(VectorVertex):
+    """健壮的向量顶点基类"""
+    
+    def execute(self, inputs, context):
+        try:
+            return super().execute(inputs, context)
+        except Exception as e:
+            error_type = type(e).__name__
+            
+            if "connection" in str(e).lower():
+                # 连接错误
+                logging.error(f"向量引擎连接失败: {e}")
+                return self._handle_connection_error(inputs, context)
+            elif "timeout" in str(e).lower():
+                # 超时错误
+                logging.warning(f"向量操作超时: {e}")
+                return self._handle_timeout_error(inputs, context)
+            elif "quota" in str(e).lower() or "limit" in str(e).lower():
+                # 配额或限制错误
+                logging.warning(f"向量服务限制: {e}")
+                return self._handle_quota_error(inputs, context)
+            else:
+                # 其他错误
+                logging.error(f"向量操作失败 ({error_type}): {e}")
+                raise e
+    
+    def _handle_connection_error(self, inputs, context):
+        """处理连接错误"""
+        # 尝试重新连接
+        try:
+            self.params["vector_engine"].reconnect()
+            return super().execute(inputs, context)
+        except:
+            return {"error": "向量引擎连接失败", "status": "failed"}
+    
+    def _handle_timeout_error(self, inputs, context):
+        """处理超时错误"""
+        # 返回部分结果或重试
+        return {"error": "操作超时", "status": "timeout"}
+    
+    def _handle_quota_error(self, inputs, context):
+        """处理配额错误"""
+        # 等待或降级处理
+        return {"error": "服务配额不足", "status": "quota_exceeded"}
+```
+
+### 性能监控
+
+```python
+import time
+from collections import defaultdict
+
+class MonitoredVectorVertex(VectorVertex):
+    """带监控的向量顶点"""
+    
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.metrics = defaultdict(list)
+        self.operation_count = 0
+    
+    def execute(self, inputs, context):
+        start_time = time.time()
+        
+        # 记录操作统计
+        operation_type = "store" if isinstance(self, VectorStoreVertex) else "query"
+        
+        if operation_type == "store":
+            vector_count = len(inputs.get("vectors", [inputs])) if "vectors" in inputs else 1
+        else:
+            vector_count = 1
+        
+        try:
+            result = super().execute(inputs, context)
+            
+            # 记录成功指标
+            execution_time = time.time() - start_time
+            self.metrics["execution_times"].append(execution_time)
+            self.metrics["vector_counts"].append(vector_count)
+            self.metrics["success_count"] += 1
+            self.operation_count += 1
+            
+            # 计算吞吐量
+            throughput = vector_count / execution_time if execution_time > 0 else 0
+            self.metrics["throughput"].append(throughput)
+            
+            logging.info(f"向量{operation_type}完成: {vector_count} 向量, {execution_time:.2f}s, {throughput:.2f} 向量/秒")
+            
+            return result
+            
+        except Exception as e:
+            self.metrics["error_count"] += 1
+            logging.error(f"向量{operation_type}失败: {e}")
+            raise e
+    
+    def get_performance_stats(self):
+        """获取性能统计"""
+        if not self.metrics["execution_times"]:
+            return {"message": "暂无性能数据"}
+        
+        import statistics
+        
+        return {
+            "总操作次数": self.operation_count,
+            "成功次数": self.metrics["success_count"],
+            "失败次数": self.metrics["error_count"],
+            "平均执行时间": statistics.mean(self.metrics["execution_times"]),
+            "平均吞吐量": statistics.mean(self.metrics["throughput"]),
+            "总处理向量数": sum(self.metrics["vector_counts"]),
+            "成功率": self.metrics["success_count"] / self.operation_count * 100 if self.operation_count > 0 else 0
+        }
+```
+
+## 最佳实践
+
+### 1. 向量维度选择
+
+```python
+# 根据应用场景选择合适的向量维度
+
+# 文本嵌入
+TEXT_DIMENSIONS = {
+    "openai_ada_002": 1536,
+    "sentence_transformers_mini": 384,
+    "sentence_transformers_base": 768,
+    "sentence_transformers_large": 1024
+}
+
+# 图像嵌入
+IMAGE_DIMENSIONS = {
+    "clip_vit_b32": 512,
+    "clip_vit_l14": 768,
+    "resnet50": 2048
+}
+
+def choose_optimal_dimension(data_type, model_name, performance_requirement):
+    """选择最优向量维度"""
+    if data_type == "text":
+        dimensions = TEXT_DIMENSIONS
+    elif data_type == "image":
+        dimensions = IMAGE_DIMENSIONS
+    else:
+        raise ValueError(f"不支持的数据类型: {data_type}")
+    
+    if model_name in dimensions:
+        return dimensions[model_name]
+    
+    # 根据性能要求选择
+    if performance_requirement == "speed":
+        return min(dimensions.values())
+    elif performance_requirement == "accuracy":
+        return max(dimensions.values())
+    else:
+        return 768  # 默认中等维度
+```
+
+### 2. 索引类型选择
+
+```python
+def choose_index_type(vector_count, query_pattern, accuracy_requirement):
+    """选择最优索引类型"""
+    
+    if vector_count < 10000:
+        # 小数据集，使用精确搜索
+        return "Flat"
+    elif vector_count < 100000:
+        # 中等数据集
+        if accuracy_requirement == "high":
+            return "HNSW"  # 高精度
+        else:
+            return "IVF"   # 平衡性能
+    else:
+        # 大数据集
+        if query_pattern == "frequent":
+            return "HNSW"  # 频繁查询
+        else:
+            return "IVF"   # 批量查询
+```
+
+### 3. 批处理策略
+
+```python
+def optimize_batch_size(vector_dimension, memory_limit_mb=1024):
+    """优化批处理大小"""
+    
+    # 估算单个向量的内存使用（字节）
+    vector_size_bytes = vector_dimension * 4  # float32
+    metadata_size_bytes = 1024  # 估算元数据大小
+    total_size_per_vector = vector_size_bytes + metadata_size_bytes
+    
+    # 计算最大批大小
+    memory_limit_bytes = memory_limit_mb * 1024 * 1024
+    max_batch_size = memory_limit_bytes // total_size_per_vector
+    
+    # 设置合理的范围
+    return max(10, min(max_batch_size, 1000))
+```
+
+### 4. 查询优化
+
+```python
+def optimize_query_parameters(collection_size, accuracy_requirement):
+    """优化查询参数"""
+    
+    if collection_size < 10000:
+        return {
+            "nprobe": collection_size // 100,  # IVF 参数
+            "ef": 200,  # HNSW 参数
+            "top_k_multiplier": 1.0
+        }
+    elif collection_size < 100000:
+        if accuracy_requirement == "high":
+            return {
+                "nprobe": collection_size // 50,
+                "ef": 400,
+                "top_k_multiplier": 1.5
+            }
+        else:
+            return {
+                "nprobe": collection_size // 100,
+                "ef": 200,
+                "top_k_multiplier": 1.2
+            }
+    else:
+        return {
+            "nprobe": min(collection_size // 100, 1000),
+            "ef": 500,
+            "top_k_multiplier": 2.0
+        }
+```
+
+## 常见问题
+
+### Q: 如何选择合适的相似度度量？
+
+A: 根据数据特性选择：
+
+```python
+SIMILARITY_METRICS = {
+    "cosine": {
+        "适用场景": ["文本嵌入", "标准化向量"],
+        "特点": "忽略向量长度，关注方向",
+        "推荐": "大多数文本应用"
+    },
+    "euclidean": {
+        "适用场景": ["图像特征", "连续数值"],
+        "特点": "考虑向量长度和方向",
+        "推荐": "空间距离重要的场景"
+    },
+    "inner_product": {
+        "适用场景": ["推荐系统", "协同过滤"],
+        "特点": "向量长度有意义",
+        "推荐": "评分预测"
+    }
+}
+```
+
+### Q: 如何处理向量维度不匹配？
+
+A: 实现维度适配器：
+
+```python
+class DimensionAdapter:
+    """向量维度适配器"""
+    
+    def __init__(self, target_dimension):
+        self.target_dimension = target_dimension
+    
+    def adapt(self, vector):
+        """适配向量维度"""
+        current_dimension = len(vector)
+        
+        if current_dimension == self.target_dimension:
+            return vector
+        elif current_dimension > self.target_dimension:
+            # 降维：截断或PCA
+            return vector[:self.target_dimension]
+        else:
+            # 升维：零填充或插值
+            padding = [0.0] * (self.target_dimension - current_dimension)
+            return vector + padding
+```
+
+### Q: 如何实现向量数据的备份和恢复？
+
+A: 实现备份机制：
+
+```python
+class VectorBackupVertex(VectorVertex):
+    """向量数据备份顶点"""
+    
+    def backup_collection(self, collection_name, backup_path):
+        """备份集合数据"""
+        import pickle
+        import os
+        
+        # 获取所有向量数据
+        vectors = self.params["vector_engine"].export_collection(collection_name)
+        
+        # 保存到文件
+        os.makedirs(os.path.dirname(backup_path), exist_ok=True)
+        with open(backup_path, 'wb') as f:
+            pickle.dump(vectors, f)
+        
+        print(f"集合 {collection_name} 已备份到 {backup_path}")
+    
+    def restore_collection(self, collection_name, backup_path):
+        """恢复集合数据"""
+        import pickle
+        
+        # 从文件加载
+        with open(backup_path, 'rb') as f:
+            vectors = pickle.load(f)
+        
+        # 恢复到向量引擎
+        self.params["vector_engine"].import_collection(collection_name, vectors)
+        
+        print(f"集合 {collection_name} 已从 {backup_path} 恢复")
+```
+
+## 总结
+
+`VectorVertex` 系列是 VertexFlow 框架中处理向量数据的核心组件，提供了：
+
+1. **完整的向量生命周期管理**: 从存储到查询的全流程支持
+2. **多引擎支持**: 兼容主流向量数据库和搜索引擎
+3. **高性能优化**: 批处理、索引优化和内存管理
+4. **企业级特性**: 错误处理、监控和备份恢复
+5. **灵活的扩展性**: 支持自定义索引类型和相似度度量
+
+通过合理使用 `VectorVertex` 系列，可以构建高效、可扩展的向量搜索和语义匹配应用。

--- a/vertex_flow/docs/vertex_group.md
+++ b/vertex_flow/docs/vertex_group.md
@@ -1,0 +1,447 @@
+# VertexGroup 文档
+
+## 概述
+
+`VertexGroup` 是 VertexFlow 框架中的一个重要组件，它允许将多个相关的 `Vertex` 组织成一个逻辑单元，形成一个子图（Subgraph）。`VertexGroup` 本身也继承自 `Vertex`，因此可以像普通顶点一样在工作流中使用，同时提供了强大的子图管理和变量暴露功能。
+
+## 设计理念
+
+### 1. 模块化设计
+- **封装复杂逻辑**: 将复杂的多步骤处理逻辑封装在一个 `VertexGroup` 中
+- **可重用性**: 创建的子图可以在不同的工作流中重复使用
+- **层次化组织**: 支持嵌套的 `VertexGroup`，实现多层次的逻辑组织
+
+### 2. 隔离性
+- **内部隔离**: 子图内部的顶点和边对外部不可见
+- **受控暴露**: 通过配置选择性地暴露内部变量和结果
+- **上下文管理**: 独立的子图上下文管理内部状态
+
+### 3. 灵活性
+- **动态构建**: 支持运行时动态添加顶点和边
+- **可配置暴露**: 灵活配置哪些变量暴露给外部
+- **标准接口**: 与普通 `Vertex` 具有相同的接口
+
+## 核心组件
+
+### SubgraphContext
+
+`SubgraphContext` 负责管理子图内部的执行上下文：
+
+```python
+class SubgraphContext:
+    def __init__(self, parent_context: WorkflowContext = None)
+    def store_internal_output(self, vertex_id: str, output_data: T)
+    def get_internal_output(self, vertex_id: str) -> T
+    def expose_variable(self, internal_vertex_id: str, variable_name: str, exposed_name: str = None)
+    def get_exposed_variables(self) -> Dict[str, Any]
+```
+
+**功能特性**:
+- 存储子图内部顶点的输出
+- 管理暴露给外部的变量
+- 与父工作流上下文的关联
+
+### VertexGroup
+
+`VertexGroup` 是主要的子图管理类：
+
+```python
+class VertexGroup(Vertex[T]):
+    def __init__(
+        self,
+        id: str,
+        name: str = None,
+        subgraph_vertices: List[Vertex[T]] = None,
+        subgraph_edges: List[Edge[T]] = None,
+        exposed_outputs: List[Dict[str, str]] = None,
+        params: Dict[str, Any] = None,
+        variables: List[Dict[str, Any]] = None,
+    )
+```
+
+## 主要功能
+
+### 1. 子图管理
+
+#### 添加顶点
+```python
+# 静态添加（初始化时）
+group = VertexGroup(
+    id="my_group",
+    subgraph_vertices=[vertex1, vertex2, vertex3]
+)
+
+# 动态添加
+group.add_subgraph_vertex(new_vertex)
+```
+
+#### 添加边
+```python
+# 静态添加（初始化时）
+group = VertexGroup(
+    id="my_group",
+    subgraph_vertices=[vertex1, vertex2],
+    subgraph_edges=[Edge(vertex1, vertex2, Always())]
+)
+
+# 动态添加
+group.add_subgraph_edge(Edge(vertex1, vertex2, Always()))
+```
+
+### 2. 拓扑排序和执行
+
+`VertexGroup` 自动对子图进行拓扑排序，确保顶点按正确的依赖顺序执行：
+
+```python
+# 获取拓扑排序结果
+execution_order = group.topological_sort_subgraph()
+
+# 执行子图
+result = group.execute_subgraph(inputs, context)
+```
+
+### 3. 变量暴露机制
+
+通过 `exposed_outputs` 配置控制哪些内部变量暴露给外部：
+
+```python
+exposed_outputs = [
+    {
+        "vertex_id": "internal_vertex_1",
+        "variable": "result",
+        "exposed_as": "step1_result"
+    },
+    {
+        "vertex_id": "internal_vertex_2",
+        "variable": "output",
+        "exposed_as": "final_output"
+    }
+]
+
+group = VertexGroup(
+    id="my_group",
+    subgraph_vertices=[vertex1, vertex2],
+    exposed_outputs=exposed_outputs
+)
+```
+
+### 4. 依赖关系解析
+
+`VertexGroup` 支持两种依赖关系：
+- **内部依赖**: 子图内顶点之间的依赖
+- **外部依赖**: 子图顶点对外部顶点的依赖
+
+```python
+# 内部依赖示例
+vertex2 = FunctionVertex(
+    id="vertex2",
+    task=some_task,
+    variables=[
+        {"source_scope": "vertex1", "source_var": "output", "local_var": "input"}
+    ]
+)
+
+# 外部依赖示例
+vertex_in_group = FunctionVertex(
+    id="internal_vertex",
+    task=some_task,
+    variables=[
+        {"source_scope": "external_vertex", "source_var": "result", "local_var": "data"}
+    ]
+)
+```
+
+## 使用示例
+
+### 基本使用
+
+```python
+from vertex_flow.workflow.vertex import VertexGroup, FunctionVertex
+from vertex_flow.workflow.edge import Edge, Always
+
+# 定义任务函数
+def add_task(inputs):
+    return {"sum": inputs["a"] + inputs["b"]}
+
+def multiply_task(inputs):
+    return {"product": inputs["value"] * inputs["factor"]}
+
+# 创建顶点
+add_vertex = FunctionVertex(id="add", task=add_task)
+multiply_vertex = FunctionVertex(
+    id="multiply", 
+    task=multiply_task,
+    variables=[{"source_scope": "add", "source_var": "sum", "local_var": "value"}]
+)
+
+# 创建子图
+calc_group = VertexGroup(
+    id="calculation_group",
+    subgraph_vertices=[add_vertex, multiply_vertex],
+    subgraph_edges=[Edge(add_vertex, multiply_vertex, Always())],
+    exposed_outputs=[
+        {"vertex_id": "add", "variable": "sum", "exposed_as": "addition_result"},
+        {"vertex_id": "multiply", "variable": "product", "exposed_as": "final_result"}
+    ]
+)
+
+# 执行子图
+inputs = {"a": 5, "b": 3, "factor": 2}
+result = calc_group.execute_subgraph(inputs)
+print(result["subgraph_outputs"])  # {"addition_result": 8, "final_result": 16}
+```
+
+### 动态构建
+
+```python
+# 创建空的 VertexGroup
+group = VertexGroup(id="dynamic_group")
+
+# 动态添加顶点
+vertex1 = FunctionVertex(id="v1", task=task1)
+vertex2 = FunctionVertex(id="v2", task=task2)
+
+group.add_subgraph_vertex(vertex1)
+group.add_subgraph_vertex(vertex2)
+
+# 动态添加边
+group.add_subgraph_edge(Edge(vertex1, vertex2, Always()))
+
+# 动态添加暴露输出
+group.add_exposed_output("v1", "result", "step1_result")
+group.add_exposed_output("v2", "output", "final_output")
+```
+
+### 嵌套使用
+
+```python
+# 创建内层子图
+inner_group = VertexGroup(
+    id="inner_group",
+    subgraph_vertices=[vertex1, vertex2],
+    subgraph_edges=[Edge(vertex1, vertex2, Always())],
+    exposed_outputs=[{"vertex_id": "vertex2", "variable": "result"}]
+)
+
+# 创建外层子图，包含内层子图
+outer_group = VertexGroup(
+    id="outer_group",
+    subgraph_vertices=[inner_group, vertex3],
+    subgraph_edges=[Edge(inner_group, vertex3, Always())]
+)
+```
+
+## 输出格式
+
+`VertexGroup` 的执行结果包含两个主要部分：
+
+```python
+{
+    "subgraph_outputs": {
+        "exposed_var1": value1,
+        "exposed_var2": value2,
+        # ... 其他暴露的变量
+    },
+    "execution_summary": {
+        "executed_vertices": ["vertex1", "vertex2", ...],
+        "total_vertices": 3,
+        "success": True,
+        "error": None  # 仅在失败时存在
+    }
+}
+```
+
+### 字段说明
+
+- **subgraph_outputs**: 根据 `exposed_outputs` 配置暴露的变量
+- **execution_summary**: 执行摘要信息
+  - `executed_vertices`: 已执行的顶点ID列表
+  - `total_vertices`: 子图中的总顶点数
+  - `success`: 执行是否成功
+  - `error`: 错误信息（仅在失败时）
+
+## 错误处理
+
+### 验证错误
+
+`VertexGroup` 在初始化时会进行以下验证：
+
+1. **边的有效性**: 确保边的源顶点和目标顶点都在子图中
+2. **暴露输出的有效性**: 确保暴露输出配置中的顶点ID存在于子图中
+
+```python
+# 这会抛出 ValueError
+group = VertexGroup(
+    id="invalid_group",
+    subgraph_vertices=[vertex1],
+    subgraph_edges=[Edge(vertex1, external_vertex, Always())]  # external_vertex 不在子图中
+)
+```
+
+### 执行错误
+
+执行过程中的错误会被捕获并记录在结果中：
+
+```python
+result = group.execute_subgraph(inputs)
+if not result["execution_summary"]["success"]:
+    print(f"执行失败: {result['execution_summary']['error']}")
+```
+
+### 循环检测
+
+`VertexGroup` 会检测子图中的循环依赖：
+
+```python
+# 这会抛出 ValueError: "Subgraph contains a cycle"
+group = VertexGroup(
+    id="cyclic_group",
+    subgraph_vertices=[vertex1, vertex2],
+    subgraph_edges=[
+        Edge(vertex1, vertex2, Always()),
+        Edge(vertex2, vertex1, Always())  # 创建循环
+    ]
+)
+group.topological_sort_subgraph()  # 抛出异常
+```
+
+## 最佳实践
+
+### 1. 合理的粒度
+
+- **功能相关性**: 将功能相关的顶点组织在同一个 `VertexGroup` 中
+- **适中的大小**: 避免创建过大或过小的子图
+- **清晰的边界**: 确保子图有明确的输入和输出边界
+
+### 2. 变量暴露策略
+
+- **最小暴露原则**: 只暴露必要的变量，保持接口简洁
+- **语义化命名**: 使用有意义的暴露变量名
+- **文档化**: 为暴露的变量提供清晰的文档说明
+
+```python
+# 好的实践
+exposed_outputs = [
+    {"vertex_id": "data_processor", "variable": "cleaned_data", "exposed_as": "processed_data"},
+    {"vertex_id": "analyzer", "variable": "summary", "exposed_as": "analysis_result"}
+]
+
+# 避免的做法
+exposed_outputs = [
+    {"vertex_id": "v1", "variable": "x", "exposed_as": "y"},  # 名称不清晰
+    {"vertex_id": "v2", "variable": "internal_state", "exposed_as": "state"}  # 暴露内部状态
+]
+```
+
+### 3. 错误处理
+
+- **验证输入**: 在子图执行前验证输入的有效性
+- **优雅降级**: 为关键错误提供备选方案
+- **详细日志**: 记录详细的执行日志便于调试
+
+### 4. 性能考虑
+
+- **避免深度嵌套**: 过深的嵌套会影响性能和可维护性
+- **合理的并行度**: 设计子图时考虑并行执行的可能性
+- **资源管理**: 注意子图中顶点的资源使用
+
+## 与现有系统的集成
+
+### 在 Workflow 中使用
+
+`VertexGroup` 可以像普通 `Vertex` 一样在 `Workflow` 中使用：
+
+```python
+from vertex_flow.workflow.workflow import Workflow
+
+# 创建工作流
+workflow = Workflow()
+
+# 添加 VertexGroup
+workflow.add_vertex(my_vertex_group)
+
+# 添加其他顶点
+workflow.add_vertex(other_vertex)
+
+# 创建边
+workflow.add_edge(Edge(my_vertex_group, other_vertex, Always()))
+
+# 执行工作流
+workflow.execute()
+```
+
+### 与其他 Vertex 类型的兼容性
+
+`VertexGroup` 与所有现有的 `Vertex` 类型兼容：
+
+- `FunctionVertex`
+- `LLMVertex`
+- `EmbeddingVertex`
+- `WhileVertex`
+- 其他自定义 `Vertex`
+
+## 测试
+
+### 单元测试
+
+```bash
+# 运行 VertexGroup 相关测试
+python -m pytest tests/test_vertex_group.py -v
+```
+
+### 集成测试
+
+```bash
+# 运行示例
+python examples/vertex_group_example.py
+```
+
+### 测试覆盖的场景
+
+- 基本子图创建和执行
+- 动态添加顶点和边
+- 变量暴露机制
+- 错误处理和验证
+- 嵌套 `VertexGroup`
+- 与 `Workflow` 的集成
+
+## 常见问题
+
+### Q: VertexGroup 与普通 Vertex 有什么区别？
+
+A: `VertexGroup` 继承自 `Vertex`，具有相同的接口，但内部包含一个子图。主要区别在于：
+- `VertexGroup` 可以包含多个顶点和边
+- 支持变量暴露机制
+- 提供子图管理功能
+- 执行时会按拓扑顺序执行内部顶点
+
+### Q: 如何处理子图中的循环依赖？
+
+A: `VertexGroup` 会在拓扑排序时检测循环依赖并抛出异常。避免循环依赖的方法：
+- 仔细设计顶点间的依赖关系
+- 使用条件边（`Condition`）而不是无条件边（`Always`）
+- 将循环逻辑封装在单个顶点中（如 `WhileVertex`）
+
+### Q: 可以在 VertexGroup 中嵌套另一个 VertexGroup 吗？
+
+A: 可以。`VertexGroup` 本身就是一个 `Vertex`，因此可以作为子顶点添加到另一个 `VertexGroup` 中，实现多层次的组织结构。
+
+### Q: 如何调试 VertexGroup 的执行？
+
+A: 可以通过以下方式调试：
+- 查看执行摘要中的 `executed_vertices` 列表
+- 检查日志输出
+- 使用 `get_subgraph_vertex()` 方法访问内部顶点的状态
+- 在开发阶段暴露更多的内部变量
+
+## 总结
+
+`VertexGroup` 是 VertexFlow 框架中的一个强大组件，它提供了：
+
+1. **模块化**: 将相关顶点组织成逻辑单元
+2. **封装性**: 隐藏内部实现细节，提供清晰的接口
+3. **灵活性**: 支持动态构建和配置
+4. **可重用性**: 创建的子图可以在多个工作流中重用
+5. **标准化**: 与现有 `Vertex` 接口完全兼容
+
+通过合理使用 `VertexGroup`，可以构建更加模块化、可维护和可扩展的工作流应用。

--- a/vertex_flow/docs/while_vertex.md
+++ b/vertex_flow/docs/while_vertex.md
@@ -1,0 +1,241 @@
+# WhileVertex 设计文档
+
+## 概述
+
+`WhileVertex` 是基于 `IfVertex` 和 `Vertex` 抽象设计的循环控制顶点，支持在工作流中实现while循环逻辑。它允许用户传入执行逻辑和判断逻辑，并支持多种循环跳出条件。
+
+## 设计特性
+
+### 1. 继承结构
+- 继承自 `FunctionVertex`
+- 遵循现有的 Vertex 抽象设计模式
+- 与现有工作流系统完全兼容
+
+### 2. 循环控制方式
+
+#### 条件判断方式
+- **condition_task**: 自定义条件判断函数
+- **conditions**: 条件列表，支持多种比较操作符
+
+#### 循环跳出条件
+- **条件判断**: 当条件不满足时跳出循环
+- **固定次数**: 通过 `max_iterations` 参数限制最大迭代次数
+- **异常处理**: 执行过程中出现异常时自动跳出
+
+### 3. 支持的操作符
+
+条件判断支持以下操作符：
+- `==`, `is`: 相等比较
+- `!=`: 不等比较
+- `>`, `<`, `>=`, `<=`: 数值比较
+- `contains`, `not_contains`: 包含关系
+- `starts_with`, `ends_with`: 字符串前缀/后缀
+- `is_empty`, `is_not_empty`: 空值检查
+
+## 类设计
+
+### WhileVertex
+
+```python
+class WhileVertex(FunctionVertex):
+    def __init__(
+        self,
+        id: str,
+        name: str = None,
+        execute_task: Callable[[Dict[str, Any], WorkflowContext[T]], Any] = None,
+        condition_task: Callable[[Dict[str, Any], WorkflowContext[T]], bool] = None,
+        conditions: List[WhileCondition] = None,
+        logical_operator: str = "and",
+        max_iterations: int = None,
+        params: Dict[str, Any] = None,
+        variables: List[Dict[str, Any]] = None,
+    )
+```
+
+#### 参数说明
+- `execute_task`: 循环体执行逻辑的函数（必需）
+- `condition_task`: 条件判断逻辑的函数（与conditions二选一）
+- `conditions`: 条件列表（与condition_task二选一）
+- `logical_operator`: 多个条件之间的逻辑操作符（"and" 或 "or"）
+- `max_iterations`: 最大迭代次数（可选）
+
+### WhileCondition
+
+```python
+class WhileCondition:
+    def __init__(
+        self,
+        variable_selector: Dict[str, str],
+        operator: str,
+        value: Any,
+        logical_operator: str = "and"
+    )
+```
+
+#### 参数说明
+- `variable_selector`: 变量选择器，包含SOURCE_SCOPE, SOURCE_VAR, LOCAL_VAR
+- `operator`: 比较操作符
+- `value`: 比较值
+- `logical_operator`: 逻辑操作符
+
+## 使用示例
+
+### 示例1：使用condition_task的简单计数
+
+```python
+from vertex_flow.workflow.vertex import WhileVertex
+from vertex_flow.workflow.workflow import Workflow, WorkflowContext
+
+# 创建工作流
+workflow = Workflow("counter_workflow")
+
+# 创建计数器
+counter = {"count": 0}
+
+def execute_logic(inputs):
+    """执行逻辑：计数器加1"""
+    counter["count"] += 1
+    return {"count": counter["count"]}
+
+def condition_logic(inputs):
+    """条件逻辑：计数器小于5时继续"""
+    return counter["count"] < 5
+
+# 创建WhileVertex
+while_vertex = WhileVertex(
+    id="counter_while",
+    name="计数循环",
+    execute_task=execute_logic,
+    condition_task=condition_logic
+)
+
+workflow.add_vertex(while_vertex)
+context = WorkflowContext(workflow)
+while_vertex.execute(inputs={}, context=context)
+
+# 结果：循环执行5次
+result = while_vertex.output
+print(f"执行了 {result['iteration_count']} 次循环")
+```
+
+### 示例2：使用conditions列表的条件判断
+
+```python
+from vertex_flow.workflow.vertex import WhileVertex, WhileCondition, SourceVertex
+from vertex_flow.workflow.constants import SOURCE_SCOPE, SOURCE_VAR, LOCAL_VAR
+
+# 创建源顶点
+source_vertex = SourceVertex(id="data_source")
+source_vertex.output = {"value": 1}
+workflow.add_vertex(source_vertex)
+
+def execute_logic(inputs):
+    """执行逻辑：值乘以2"""
+    current_value = inputs.get("value", 1)
+    new_value = current_value * 2
+    source_vertex.output = {"value": new_value}
+    return {"value": new_value}
+
+# 创建条件：value < 100
+condition = WhileCondition(
+    variable_selector={
+        SOURCE_SCOPE: "data_source",
+        SOURCE_VAR: "value",
+        LOCAL_VAR: "value"
+    },
+    operator="<",
+    value=100
+)
+
+while_vertex = WhileVertex(
+    id="multiply_while",
+    execute_task=execute_logic,
+    conditions=[condition],
+    variables=[
+        {
+            SOURCE_SCOPE: "data_source",
+            SOURCE_VAR: "value",
+            LOCAL_VAR: "value"
+        }
+    ]
+)
+```
+
+### 示例3：最大迭代次数限制
+
+```python
+while_vertex = WhileVertex(
+    id="limited_while",
+    execute_task=execute_logic,
+    condition_task=lambda inputs: True,  # 无限循环条件
+    max_iterations=10  # 最多执行10次
+)
+```
+
+## 输出格式
+
+WhileVertex的输出包含以下信息：
+
+```python
+{
+    "results": [result1, result2, ...],  # 每次迭代的结果列表
+    "iteration_count": 5,                # 实际执行的迭代次数
+    "final_inputs": {...}               # 最终的输入状态
+}
+```
+
+## 错误处理
+
+### 验证错误
+- 缺少 `execute_task` 时抛出 ValueError
+- 同时缺少 `condition_task` 和 `conditions` 时抛出 ValueError
+- 同时提供 `condition_task` 和 `conditions` 时抛出 ValueError
+- 无效的 `logical_operator` 时抛出 ValueError
+
+### 运行时错误
+- 变量不存在时抛出 ValueError
+- 不支持的操作符时抛出 ValueError
+- 执行过程中的异常会被捕获并记录，循环会自动跳出
+
+## 最佳实践
+
+1. **选择合适的条件方式**
+   - 简单条件使用 `condition_task`
+   - 复杂条件或需要变量依赖时使用 `conditions`
+
+2. **设置最大迭代次数**
+   - 总是设置 `max_iterations` 避免无限循环
+   - 根据业务需求合理设置上限
+
+3. **错误处理**
+   - 在 `execute_task` 中添加适当的错误处理
+   - 使用日志记录循环执行状态
+
+4. **性能考虑**
+   - 避免在循环中进行重量级操作
+   - 合理设计循环退出条件
+
+## 与现有系统的集成
+
+WhileVertex已经集成到现有的vertex系统中：
+
+1. **模块导入**: 已添加到 `vertex_flow.workflow.vertex.__init__.py`
+2. **工作流兼容**: 完全兼容现有的Workflow和WorkflowContext
+3. **边连接**: 支持使用 `.to()` 方法连接其他顶点
+4. **变量依赖**: 支持现有的变量依赖解析机制
+
+## 测试
+
+项目包含完整的测试套件：
+- `test_while_vertex.py`: 单元测试
+- `while_vertex_example.py`: 使用示例
+
+运行测试：
+```bash
+python -m pytest vertex_flow/tests/test_while_vertex.py -v
+```
+
+运行示例：
+```bash
+python vertex_flow/examples/while_vertex_example.py
+```

--- a/vertex_flow/examples/vertex_group_example.py
+++ b/vertex_flow/examples/vertex_group_example.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python3
+"""
+VertexGroup 使用示例
+
+本文件展示了如何使用 VertexGroup 创建和执行包含多个顶点的子图。
+VertexGroup 允许将多个相关的顶点组织成一个逻辑单元，并控制哪些变量暴露给外部。
+"""
+
+import os
+import sys
+
+# 添加项目根目录到路径
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from vertex_flow.workflow.edge import Always, Edge
+from vertex_flow.workflow.vertex import FunctionVertex, VertexGroup
+from vertex_flow.workflow.workflow import WorkflowContext
+
+
+def example_1_simple_calculation_subgraph():
+    """
+    示例1: 简单计算子图
+    创建一个包含加法和乘法操作的子图
+    """
+    print("\n=== 示例1: 简单计算子图 ===")
+
+    # 定义任务函数
+    def add_task(inputs):
+        a = inputs.get("a", 0)
+        b = inputs.get("b", 0)
+        result = a + b
+        print(f"  加法: {a} + {b} = {result}")
+        return {"sum": result}
+
+    def multiply_task(inputs):
+        value = inputs.get("value", 1)
+        factor = inputs.get("factor", 2)
+        result = value * factor
+        print(f"  乘法: {value} * {factor} = {result}")
+        return {"product": result}
+
+    # 创建顶点
+    add_vertex = FunctionVertex(id="add_vertex", name="加法顶点", task=add_task)
+
+    multiply_vertex = FunctionVertex(
+        id="multiply_vertex",
+        name="乘法顶点",
+        task=multiply_task,
+        variables=[{"source_scope": "add_vertex", "source_var": "sum", "local_var": "value"}],
+    )
+
+    # 创建边
+    edge = Edge(add_vertex, multiply_vertex, Always())
+
+    # 定义暴露输出
+    exposed_outputs = [
+        {"vertex_id": "add_vertex", "variable": "sum", "exposed_as": "addition_result"},
+        {"vertex_id": "multiply_vertex", "variable": "product", "exposed_as": "final_result"},
+    ]
+
+    # 创建VertexGroup
+    calc_group = VertexGroup(
+        id="calculation_group",
+        name="计算组",
+        subgraph_vertices=[add_vertex, multiply_vertex],
+        subgraph_edges=[edge],
+        exposed_outputs=exposed_outputs,
+    )
+
+    # 执行子图
+    inputs = {"a": 10, "b": 5, "factor": 3}
+    context = WorkflowContext()
+
+    print(f"输入: {inputs}")
+    result = calc_group.execute_subgraph(inputs, context)
+
+    print(f"暴露的输出: {result['subgraph_outputs']}")
+    print(f"执行摘要: {result['execution_summary']}")
+
+    return calc_group
+
+
+def example_2_data_processing_pipeline():
+    """
+    示例2: 数据处理管道
+    创建一个数据处理管道，包含数据清洗、转换和聚合步骤
+    """
+    print("\n=== 示例2: 数据处理管道 ===")
+
+    # 数据清洗任务
+    def clean_data_task(inputs):
+        raw_data = inputs.get("raw_data", [])
+        # 移除空值和负数
+        cleaned = [x for x in raw_data if x is not None and x >= 0]
+        print(f"  数据清洗: {len(raw_data)} -> {len(cleaned)} 条记录")
+        return {"cleaned_data": cleaned}
+
+    # 数据转换任务
+    def transform_data_task(inputs):
+        data = inputs.get("data", [])
+        multiplier = inputs.get("multiplier", 1)
+        # 将每个值乘以倍数
+        transformed = [x * multiplier for x in data]
+        print(f"  数据转换: 乘以 {multiplier}")
+        return {"transformed_data": transformed}
+
+    # 数据聚合任务
+    def aggregate_data_task(inputs):
+        data = inputs.get("data", [])
+        if not data:
+            return {"sum": 0, "avg": 0, "count": 0}
+
+        total = sum(data)
+        count = len(data)
+        average = total / count
+        print(f"  数据聚合: 总和={total}, 平均值={average:.2f}, 数量={count}")
+        return {"sum": total, "avg": average, "count": count}
+
+    # 创建顶点
+    clean_vertex = FunctionVertex(id="clean_vertex", name="数据清洗", task=clean_data_task)
+
+    transform_vertex = FunctionVertex(
+        id="transform_vertex",
+        name="数据转换",
+        task=transform_data_task,
+        variables=[{"source_scope": "clean_vertex", "source_var": "cleaned_data", "local_var": "data"}],
+    )
+
+    aggregate_vertex = FunctionVertex(
+        id="aggregate_vertex",
+        name="数据聚合",
+        task=aggregate_data_task,
+        variables=[{"source_scope": "transform_vertex", "source_var": "transformed_data", "local_var": "data"}],
+    )
+
+    # 创建边
+    edge1 = Edge(clean_vertex, transform_vertex, Always())
+    edge2 = Edge(transform_vertex, aggregate_vertex, Always())
+
+    # 定义暴露输出
+    exposed_outputs = [
+        {"vertex_id": "clean_vertex", "variable": "cleaned_data", "exposed_as": "clean_data"},
+        {"vertex_id": "aggregate_vertex", "variable": "sum", "exposed_as": "total_sum"},
+        {"vertex_id": "aggregate_vertex", "variable": "avg", "exposed_as": "average"},
+        {"vertex_id": "aggregate_vertex", "variable": "count", "exposed_as": "record_count"},
+    ]
+
+    # 创建VertexGroup
+    pipeline_group = VertexGroup(
+        id="data_pipeline_group",
+        name="数据处理管道",
+        subgraph_vertices=[clean_vertex, transform_vertex, aggregate_vertex],
+        subgraph_edges=[edge1, edge2],
+        exposed_outputs=exposed_outputs,
+    )
+
+    # 执行管道
+    inputs = {"raw_data": [1, 2, -1, 3, None, 4, 5, -2, 6], "multiplier": 2}
+    context = WorkflowContext()
+
+    print(f"原始数据: {inputs['raw_data']}")
+    print(f"转换倍数: {inputs['multiplier']}")
+
+    result = pipeline_group.execute_subgraph(inputs, context)
+
+    print(f"\n处理结果:")
+    for key, value in result["subgraph_outputs"].items():
+        print(f"  {key}: {value}")
+
+    return pipeline_group
+
+
+def example_3_nested_vertex_groups():
+    """
+    示例3: 嵌套VertexGroup
+    展示如何在工作流中使用VertexGroup作为普通顶点
+    """
+    print("\n=== 示例3: 嵌套VertexGroup ===")
+
+    # 创建一个简单的计算子图
+    def square_task(inputs):
+        value = inputs.get("value", 0)
+        result = value**2
+        print(f"  平方: {value}^2 = {result}")
+        return {"squared": result}
+
+    def sqrt_task(inputs):
+        value = inputs.get("value", 0)
+        result = value**0.5
+        print(f"  开方: √{value} = {result:.2f}")
+        return {"sqrt": result}
+
+    # 创建子图顶点
+    square_vertex = FunctionVertex(id="square_vertex", name="平方", task=square_task)
+
+    sqrt_vertex = FunctionVertex(
+        id="sqrt_vertex",
+        name="开方",
+        task=sqrt_task,
+        variables=[{"source_scope": "square_vertex", "source_var": "squared", "local_var": "value"}],
+    )
+
+    # 创建子图
+    math_group = VertexGroup(
+        id="math_group",
+        name="数学运算组",
+        subgraph_vertices=[square_vertex, sqrt_vertex],
+        subgraph_edges=[Edge(square_vertex, sqrt_vertex, Always())],
+        exposed_outputs=[
+            {"vertex_id": "square_vertex", "variable": "squared", "exposed_as": "square_result"},
+            {"vertex_id": "sqrt_vertex", "variable": "sqrt", "exposed_as": "sqrt_result"},
+        ],
+    )
+
+    # 创建外部处理顶点
+    def final_process_task(inputs):
+        square_result = inputs.get("square_result", 0)
+        sqrt_result = inputs.get("sqrt_result", 0)
+        difference = abs(square_result - sqrt_result)
+        print(f"  最终处理: |{square_result} - {sqrt_result:.2f}| = {difference:.2f}")
+        return {"difference": difference}
+
+    final_vertex = FunctionVertex(id="final_vertex", name="最终处理", task=final_process_task)
+
+    # 执行数学运算组
+    inputs = {"value": 16}
+    context = WorkflowContext()
+
+    print(f"输入值: {inputs['value']}")
+
+    # 执行子图
+    math_result = math_group.execute_subgraph(inputs, context)
+    print(f"数学运算组输出: {math_result['subgraph_outputs']}")
+
+    # 使用子图输出作为最终处理的输入
+    final_inputs = math_result["subgraph_outputs"]
+    final_vertex.execute(inputs=final_inputs, context=context)
+    print(f"最终结果: {final_vertex.output}")
+
+    return math_group, final_vertex
+
+
+def example_4_dynamic_subgraph_construction():
+    """
+    示例4: 动态子图构建
+    展示如何动态添加顶点和边到VertexGroup
+    """
+    print("\n=== 示例4: 动态子图构建 ===")
+
+    # 创建空的VertexGroup
+    dynamic_group = VertexGroup(id="dynamic_group", name="动态构建组")
+
+    # 动态添加顶点
+    def step1_task(inputs):
+        value = inputs.get("start_value", 1)
+        result = value + 10
+        print(f"  步骤1: {value} + 10 = {result}")
+        return {"step1_result": result}
+
+    def step2_task(inputs):
+        value = inputs.get("input_value", 0)
+        result = value * 2
+        print(f"  步骤2: {value} * 2 = {result}")
+        return {"step2_result": result}
+
+    def step3_task(inputs):
+        value = inputs.get("input_value", 0)
+        result = value - 5
+        print(f"  步骤3: {value} - 5 = {result}")
+        return {"step3_result": result}
+
+    # 创建并添加顶点
+    step1_vertex = FunctionVertex(id="step1", name="步骤1", task=step1_task)
+    step2_vertex = FunctionVertex(
+        id="step2",
+        name="步骤2",
+        task=step2_task,
+        variables=[{"source_scope": "step1", "source_var": "step1_result", "local_var": "input_value"}],
+    )
+    step3_vertex = FunctionVertex(
+        id="step3",
+        name="步骤3",
+        task=step3_task,
+        variables=[{"source_scope": "step2", "source_var": "step2_result", "local_var": "input_value"}],
+    )
+
+    # 动态添加到组中
+    dynamic_group.add_subgraph_vertex(step1_vertex)
+    dynamic_group.add_subgraph_vertex(step2_vertex)
+    dynamic_group.add_subgraph_vertex(step3_vertex)
+
+    # 动态添加边
+    dynamic_group.add_subgraph_edge(Edge(step1_vertex, step2_vertex, Always()))
+    dynamic_group.add_subgraph_edge(Edge(step2_vertex, step3_vertex, Always()))
+
+    # 动态添加暴露输出
+    dynamic_group.add_exposed_output("step1", "step1_result", "first_step")
+    dynamic_group.add_exposed_output("step2", "step2_result", "second_step")
+    dynamic_group.add_exposed_output("step3", "step3_result", "final_step")
+
+    print(f"动态构建的子图信息:")
+    print(f"  顶点数量: {len(dynamic_group.get_subgraph_vertices())}")
+    print(f"  边数量: {len(dynamic_group.get_subgraph_edges())}")
+    print(f"  暴露输出数量: {len(dynamic_group.exposed_outputs)}")
+
+    # 执行动态构建的子图
+    inputs = {"start_value": 5}
+    context = WorkflowContext()
+
+    print(f"\n执行动态子图，输入: {inputs}")
+    result = dynamic_group.execute_subgraph(inputs, context)
+
+    print(f"执行结果:")
+    for key, value in result["subgraph_outputs"].items():
+        print(f"  {key}: {value}")
+
+    return dynamic_group
+
+
+def main():
+    """
+    运行所有示例
+    """
+    print("VertexGroup 使用示例")
+    print("=" * 50)
+
+    try:
+        # 运行示例
+        example_1_simple_calculation_subgraph()
+        example_2_data_processing_pipeline()
+        example_3_nested_vertex_groups()
+        example_4_dynamic_subgraph_construction()
+
+        print("\n=== 所有示例执行完成 ===")
+
+    except Exception as e:
+        print(f"\n执行示例时出错: {e}")
+        import traceback
+
+        traceback.print_exc()
+
+
+if __name__ == "__main__":
+    main()

--- a/vertex_flow/tests/test_vertex_group.py
+++ b/vertex_flow/tests/test_vertex_group.py
@@ -1,0 +1,302 @@
+from unittest.mock import Mock
+
+import pytest
+
+from vertex_flow.workflow.edge import Always, Edge
+from vertex_flow.workflow.vertex import FunctionVertex, SubgraphContext, VertexGroup
+from vertex_flow.workflow.workflow import WorkflowContext
+
+
+class TestSubgraphContext:
+    """测试SubgraphContext类"""
+
+    def test_init(self):
+        """测试SubgraphContext初始化"""
+        parent_context = WorkflowContext()
+        context = SubgraphContext(parent_context)
+
+        assert context.parent_context == parent_context
+        assert context.internal_outputs == {}
+        assert context.exposed_variables == {}
+
+    def test_store_and_get_internal_output(self):
+        """测试存储和获取内部输出"""
+        context = SubgraphContext()
+
+        # 存储输出
+        context.store_internal_output("vertex1", {"result": 42})
+        context.store_internal_output("vertex2", "hello")
+
+        # 获取输出
+        assert context.get_internal_output("vertex1") == {"result": 42}
+        assert context.get_internal_output("vertex2") == "hello"
+        assert context.get_internal_output("nonexistent") is None
+
+    def test_expose_variable(self):
+        """测试暴露变量"""
+        context = SubgraphContext()
+
+        # 存储一些内部输出
+        context.store_internal_output("vertex1", {"x": 10, "y": 20})
+        context.store_internal_output("vertex2", "simple_value")
+
+        # 暴露字典中的特定变量
+        context.expose_variable("vertex1", "x", "exposed_x")
+        context.expose_variable("vertex1", "y")  # 使用原名
+
+        # 暴露整个值
+        context.expose_variable("vertex2", None, "simple")
+
+        exposed = context.get_exposed_variables()
+        assert exposed["exposed_x"] == 10
+        assert exposed["y"] == 20
+        assert exposed["simple"] == "simple_value"
+
+
+class TestVertexGroup:
+    """测试VertexGroup类"""
+
+    def create_simple_vertices(self):
+        """创建简单的测试顶点"""
+
+        def add_task(inputs):
+            a = inputs.get("a", 0)
+            b = inputs.get("b", 0)
+            return {"sum": a + b}
+
+        def multiply_task(inputs):
+            value = inputs.get("value", 1)
+            factor = inputs.get("factor", 2)
+            return {"product": value * factor}
+
+        vertex1 = FunctionVertex(id="add_vertex", name="Add Vertex", task=add_task)
+
+        vertex2 = FunctionVertex(
+            id="multiply_vertex",
+            name="Multiply Vertex",
+            task=multiply_task,
+            variables=[{"source_scope": "add_vertex", "source_var": "sum", "local_var": "value"}],
+        )
+
+        return vertex1, vertex2
+
+    def test_init(self):
+        """测试VertexGroup初始化"""
+        vertex1, vertex2 = self.create_simple_vertices()
+        edge = Edge(vertex1, vertex2, Always())
+
+        exposed_outputs = [
+            {"vertex_id": "add_vertex", "variable": "sum", "exposed_as": "addition_result"},
+            {"vertex_id": "multiply_vertex", "variable": "product", "exposed_as": "final_result"},
+        ]
+
+        group = VertexGroup(
+            id="test_group",
+            name="Test Group",
+            subgraph_vertices=[vertex1, vertex2],
+            subgraph_edges=[edge],
+            exposed_outputs=exposed_outputs,
+        )
+
+        assert group.id == "test_group"
+        assert group.name == "Test Group"
+        assert len(group.subgraph_vertices) == 2
+        assert len(group.subgraph_edges) == 1
+        assert len(group.exposed_outputs) == 2
+        assert vertex1._vertex_group_ref == group
+        assert vertex2._vertex_group_ref == group
+
+    def test_validate_subgraph_invalid_edge(self):
+        """测试子图验证 - 无效边"""
+        vertex1, vertex2 = self.create_simple_vertices()
+
+        # 创建一个不在子图中的顶点
+        external_vertex = FunctionVertex(id="external", task=lambda inputs: inputs)
+        invalid_edge = Edge(vertex1, external_vertex, Always())
+
+        with pytest.raises(ValueError, match="Edge .* contains vertices not in subgraph"):
+            VertexGroup(id="invalid_group", subgraph_vertices=[vertex1, vertex2], subgraph_edges=[invalid_edge])
+
+    def test_validate_subgraph_invalid_exposed_output(self):
+        """测试子图验证 - 无效暴露输出"""
+        vertex1, vertex2 = self.create_simple_vertices()
+
+        exposed_outputs = [{"vertex_id": "nonexistent_vertex", "variable": "some_var"}]
+
+        with pytest.raises(ValueError, match="Exposed output vertex_id .* not found in subgraph"):
+            VertexGroup(id="invalid_group", subgraph_vertices=[vertex1, vertex2], exposed_outputs=exposed_outputs)
+
+    def test_add_subgraph_vertex(self):
+        """测试添加子图顶点"""
+        group = VertexGroup(id="test_group")
+        vertex = FunctionVertex(id="new_vertex", task=lambda inputs: inputs)
+
+        result = group.add_subgraph_vertex(vertex)
+
+        assert result == vertex
+        assert vertex.id in group.subgraph_vertices
+        assert vertex._vertex_group_ref == group
+
+    def test_add_subgraph_edge(self):
+        """测试添加子图边"""
+        vertex1, vertex2 = self.create_simple_vertices()
+        group = VertexGroup(id="test_group", subgraph_vertices=[vertex1, vertex2])
+
+        edge = Edge(vertex1, vertex2, Always())
+        group.add_subgraph_edge(edge)
+
+        assert edge in group.subgraph_edges
+        assert vertex2.in_degree > 0
+        assert vertex1.out_degree > 0
+        assert vertex1.id in vertex2.dependencies
+
+    def test_add_subgraph_edge_invalid_vertices(self):
+        """测试添加子图边 - 无效顶点"""
+        vertex1, vertex2 = self.create_simple_vertices()
+        external_vertex = FunctionVertex(id="external", task=lambda inputs: inputs)
+
+        group = VertexGroup(id="test_group", subgraph_vertices=[vertex1, vertex2])
+
+        invalid_edge = Edge(vertex1, external_vertex, Always())
+
+        with pytest.raises(ValueError, match="Both vertices must be in the subgraph"):
+            group.add_subgraph_edge(invalid_edge)
+
+    def test_get_subgraph_sources(self):
+        """测试获取子图源顶点"""
+        vertex1, vertex2 = self.create_simple_vertices()
+        edge = Edge(vertex1, vertex2, Always())
+
+        group = VertexGroup(id="test_group", subgraph_vertices=[vertex1, vertex2], subgraph_edges=[edge])
+
+        sources = group.get_subgraph_sources()
+        assert len(sources) == 1
+        assert sources[0] == vertex1
+
+    def test_get_subgraph_sinks(self):
+        """测试获取子图汇顶点"""
+        vertex1, vertex2 = self.create_simple_vertices()
+        edge = Edge(vertex1, vertex2, Always())
+
+        group = VertexGroup(id="test_group", subgraph_vertices=[vertex1, vertex2], subgraph_edges=[edge])
+
+        sinks = group.get_subgraph_sinks()
+        assert len(sinks) == 1
+        assert sinks[0] == vertex2
+
+    def test_topological_sort_subgraph(self):
+        """测试子图拓扑排序"""
+        vertex1, vertex2 = self.create_simple_vertices()
+        edge = Edge(vertex1, vertex2, Always())
+
+        group = VertexGroup(id="test_group", subgraph_vertices=[vertex1, vertex2], subgraph_edges=[edge])
+
+        order = group.topological_sort_subgraph()
+        assert len(order) == 2
+        assert order[0] == vertex1  # vertex1应该在vertex2之前
+        assert order[1] == vertex2
+
+    def test_topological_sort_subgraph_cycle(self):
+        """测试子图拓扑排序 - 循环检测"""
+        vertex1, vertex2 = self.create_simple_vertices()
+        edge1 = Edge(vertex1, vertex2, Always())
+        edge2 = Edge(vertex2, vertex1, Always())  # 创建循环
+
+        group = VertexGroup(id="test_group", subgraph_vertices=[vertex1, vertex2], subgraph_edges=[edge1, edge2])
+
+        with pytest.raises(ValueError, match="Subgraph contains a cycle"):
+            group.topological_sort_subgraph()
+
+    def test_execute_subgraph_simple(self):
+        """测试简单子图执行"""
+        vertex1, vertex2 = self.create_simple_vertices()
+        edge = Edge(vertex1, vertex2, Always())
+
+        exposed_outputs = [
+            {"vertex_id": "add_vertex", "variable": "sum", "exposed_as": "addition_result"},
+            {"vertex_id": "multiply_vertex", "variable": "product", "exposed_as": "final_result"},
+        ]
+
+        group = VertexGroup(
+            id="test_group",
+            subgraph_vertices=[vertex1, vertex2],
+            subgraph_edges=[edge],
+            exposed_outputs=exposed_outputs,
+        )
+
+        # 执行子图
+        inputs = {"a": 5, "b": 3, "factor": 4}
+        context = WorkflowContext()
+
+        result = group.execute_subgraph(inputs, context)
+
+        # 验证结果
+        assert result["execution_summary"]["success"] is True
+        assert len(result["execution_summary"]["executed_vertices"]) == 2
+
+        # 验证暴露的输出
+        exposed = result["subgraph_outputs"]
+        assert exposed["addition_result"] == 8  # 5 + 3
+        assert exposed["final_result"] == 32  # 8 * 4
+
+    def test_execute_subgraph_no_vertices(self):
+        """测试空子图执行"""
+        group = VertexGroup(id="empty_group")
+
+        result = group.execute_subgraph()
+
+        assert result["execution_summary"]["success"] is True
+        assert result["execution_summary"]["total_vertices"] == 0
+        assert result["subgraph_outputs"] == {}
+
+    def test_add_exposed_output(self):
+        """测试添加暴露输出配置"""
+        group = VertexGroup(id="test_group")
+
+        group.add_exposed_output("vertex1", "var1", "exposed_var1")
+        group.add_exposed_output("vertex2", "var2")  # 使用默认暴露名
+
+        assert len(group.exposed_outputs) == 2
+        assert group.exposed_outputs[0] == {"vertex_id": "vertex1", "variable": "var1", "exposed_as": "exposed_var1"}
+        assert group.exposed_outputs[1] == {"vertex_id": "vertex2", "variable": "var2", "exposed_as": "var2"}
+
+    def test_get_methods(self):
+        """测试获取方法"""
+        vertex1, vertex2 = self.create_simple_vertices()
+        edge = Edge(vertex1, vertex2, Always())
+
+        group = VertexGroup(id="test_group", subgraph_vertices=[vertex1, vertex2], subgraph_edges=[edge])
+
+        # 测试获取子图顶点
+        assert group.get_subgraph_vertex("add_vertex") == vertex1
+        assert group.get_subgraph_vertex("nonexistent") is None
+
+        # 测试获取所有顶点
+        vertices = group.get_subgraph_vertices()
+        assert len(vertices) == 2
+        assert "add_vertex" in vertices
+        assert "multiply_vertex" in vertices
+
+        # 测试获取所有边
+        edges = group.get_subgraph_edges()
+        assert len(edges) == 1
+        assert edge in edges
+
+    def test_str_and_repr(self):
+        """测试字符串表示"""
+        vertex1, vertex2 = self.create_simple_vertices()
+        edge = Edge(vertex1, vertex2, Always())
+
+        group = VertexGroup(id="test_group", subgraph_vertices=[vertex1, vertex2], subgraph_edges=[edge])
+
+        str_repr = str(group)
+        assert "VertexGroup" in str_repr
+        assert "test_group" in str_repr
+        assert "vertices=2" in str_repr
+        assert "edges=1" in str_repr
+
+        assert repr(group) == str(group)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/vertex_flow/tests/test_while_vertex.py
+++ b/vertex_flow/tests/test_while_vertex.py
@@ -1,0 +1,205 @@
+from unittest.mock import Mock
+
+import pytest
+
+from vertex_flow.workflow.constants import LOCAL_VAR, SOURCE_SCOPE, SOURCE_VAR
+from vertex_flow.workflow.context import WorkflowContext
+from vertex_flow.workflow.vertex import WhileCondition, WhileVertex
+from vertex_flow.workflow.workflow import Workflow
+
+
+class TestWhileVertex:
+    """WhileVertex的测试类"""
+
+    def test_while_vertex_with_condition_task(self):
+        """测试使用condition_task的WhileVertex"""
+        # 创建工作流
+        workflow = Workflow("test_while_workflow")
+
+        # 创建计数器变量
+        counter = {"count": 0}
+
+        def execute_logic(inputs):
+            """执行逻辑：计数器加1"""
+            counter["count"] += 1
+            return {"count": counter["count"]}
+
+        def condition_logic(inputs):
+            """条件逻辑：计数器小于3时继续"""
+            return counter["count"] < 3
+
+        # 创建WhileVertex
+        while_vertex = WhileVertex(
+            id="while_test", name="While Test", execute_task=execute_logic, condition_task=condition_logic
+        )
+
+        # 添加到工作流
+        workflow.add_vertex(while_vertex)
+
+        # 创建上下文
+        context = WorkflowContext(workflow)
+
+        # 执行
+        while_vertex.execute(inputs={}, context=context)
+
+        # 验证结果
+        result = while_vertex.output
+        assert result["iteration_count"] == 3
+        assert len(result["results"]) == 3
+        assert result["results"][-1]["count"] == 3
+
+    def test_while_vertex_with_conditions_list(self):
+        """测试使用conditions列表的WhileVertex"""
+        # 创建工作流
+        workflow = Workflow("test_while_workflow")
+
+        # 创建源顶点提供计数器
+        from vertex_flow.workflow.vertex import SourceVertex
+
+        source_vertex = SourceVertex(id="counter_source", name="Counter Source")
+        source_vertex.output = {"count": 0}
+        workflow.add_vertex(source_vertex)
+
+        def execute_logic(inputs):
+            """执行逻辑：计数器加1"""
+            current_count = inputs.get("count", 0)
+            new_count = current_count + 1
+            # 更新源顶点的输出
+            source_vertex.output = {"count": new_count}
+            return {"count": new_count}
+
+        # 创建条件：count < 5
+        condition = WhileCondition(
+            variable_selector={SOURCE_SCOPE: "counter_source", SOURCE_VAR: "count", LOCAL_VAR: "count"},
+            operator="<",
+            value=5,
+        )
+
+        # 创建WhileVertex
+        while_vertex = WhileVertex(
+            id="while_test",
+            name="While Test",
+            execute_task=execute_logic,
+            conditions=[condition],
+            variables=[{SOURCE_SCOPE: "counter_source", SOURCE_VAR: "count", LOCAL_VAR: "count"}],
+        )
+
+        # 添加到工作流
+        workflow.add_vertex(while_vertex)
+
+        # 创建上下文
+        context = WorkflowContext(workflow)
+
+        # 执行
+        while_vertex.execute(inputs={"count": 0}, context=context)
+
+        # 验证结果
+        result = while_vertex.output
+        assert result["iteration_count"] == 5
+        assert len(result["results"]) == 5
+        assert result["results"][-1]["count"] == 5
+
+    def test_while_vertex_with_max_iterations(self):
+        """测试最大迭代次数限制"""
+        # 创建工作流
+        workflow = Workflow("test_while_workflow")
+
+        def execute_logic(inputs):
+            """执行逻辑：简单返回"""
+            return {"executed": True}
+
+        def condition_logic(inputs):
+            """条件逻辑：总是返回True（无限循环）"""
+            return True
+
+        # 创建WhileVertex，设置最大迭代次数为3
+        while_vertex = WhileVertex(
+            id="while_test",
+            name="While Test",
+            execute_task=execute_logic,
+            condition_task=condition_logic,
+            max_iterations=3,
+        )
+
+        # 添加到工作流
+        workflow.add_vertex(while_vertex)
+
+        # 创建上下文
+        context = WorkflowContext(workflow)
+
+        # 执行
+        while_vertex.execute(inputs={}, context=context)
+
+        # 验证结果
+        result = while_vertex.output
+        assert result["iteration_count"] == 3
+        assert len(result["results"]) == 3
+
+    def test_while_vertex_validation_errors(self):
+        """测试WhileVertex的验证错误"""
+        # 测试缺少execute_task
+        with pytest.raises(ValueError, match="execute_task is required"):
+            WhileVertex(id="test", execute_task=None, condition_task=lambda inputs: True)
+
+        # 测试缺少条件
+        with pytest.raises(ValueError, match="Either condition_task or conditions must be provided"):
+            WhileVertex(id="test", execute_task=lambda inputs: {}, condition_task=None, conditions=None)
+
+        # 测试同时提供两种条件
+        with pytest.raises(ValueError, match="Cannot provide both condition_task and conditions"):
+            WhileVertex(
+                id="test",
+                execute_task=lambda inputs: {},
+                condition_task=lambda inputs: True,
+                conditions=[WhileCondition({SOURCE_VAR: "test"}, "==", "value")],
+            )
+
+        # 测试无效的逻辑操作符
+        with pytest.raises(ValueError, match="Unsupported logical operator"):
+            WhileVertex(
+                id="test",
+                execute_task=lambda inputs: {},
+                condition_task=lambda inputs: True,
+                logical_operator="invalid",
+            )
+
+    def test_while_condition_operators(self):
+        """测试WhileCondition的各种操作符"""
+        # 创建工作流
+        workflow = Workflow("test_while_workflow")
+
+        # 创建源顶点
+        from vertex_flow.workflow.vertex import SourceVertex
+
+        source_vertex = SourceVertex(id="test_source", name="Test Source")
+        source_vertex.output = {"value": "hello world"}
+        workflow.add_vertex(source_vertex)
+
+        def execute_logic(inputs):
+            return {"executed": True}
+
+        # 测试contains操作符
+        condition = WhileCondition(
+            variable_selector={SOURCE_SCOPE: "test_source", SOURCE_VAR: "value", LOCAL_VAR: "value"},
+            operator="contains",
+            value="world",
+        )
+
+        while_vertex = WhileVertex(
+            id="while_test",
+            execute_task=execute_logic,
+            conditions=[condition],
+            max_iterations=1,  # 只执行一次
+            variables=[{SOURCE_SCOPE: "test_source", SOURCE_VAR: "value", LOCAL_VAR: "value"}],
+        )
+
+        workflow.add_vertex(while_vertex)
+        context = WorkflowContext(workflow)
+
+        # 执行
+        while_vertex.execute(inputs={}, context=context)
+
+        # 验证结果
+        result = while_vertex.output
+        assert result["iteration_count"] == 1
+        assert len(result["results"]) == 1

--- a/vertex_flow/tests/test_workflow_integration.py
+++ b/vertex_flow/tests/test_workflow_integration.py
@@ -1,0 +1,352 @@
+import pytest
+
+from vertex_flow.utils.logger import logging
+from vertex_flow.workflow.constants import LOCAL_VAR, SOURCE_SCOPE, SOURCE_VAR
+from vertex_flow.workflow.edge import Always, Edge
+from vertex_flow.workflow.vertex import FunctionVertex, SinkVertex, SourceVertex, VertexGroup
+from vertex_flow.workflow.workflow import Workflow, WorkflowContext
+
+logger = logging.getLogger()
+
+
+class TestWorkflowIntegration:
+    """测试VertexGroup与普通Vertex在Workflow中的集成"""
+
+    def create_simple_vertex_group(self):
+        """创建一个简单的VertexGroup"""
+
+        # 创建子图中的顶点
+        def add_task(inputs):
+            logger.info(f"Add task executed with inputs: {inputs}")
+            a = inputs.get("a", 0)
+            b = inputs.get("b", 0)
+            return {"sum": a + b}
+
+        def multiply_task(inputs):
+            logger.info(f"Multiply task executed with inputs: {inputs}")
+            value = inputs.get("sum", 0)
+            factor = inputs.get("factor", 1)
+            return {"product": value * factor}
+
+        add_vertex = FunctionVertex(id="add_vertex", name="Add Vertex", task=add_task)
+
+        # 设置add_vertex的变量依赖 - 从输入获取a和b
+        add_vertex.add_variable("source", "a", "a")
+        add_vertex.add_variable("source", "b", "b")
+
+        multiply_vertex = FunctionVertex(id="multiply_vertex", name="Multiply Vertex", task=multiply_task)
+
+        # 设置multiply_vertex的变量依赖
+        multiply_vertex.add_variable("add_vertex", "sum", "sum")
+        multiply_vertex.add_variable("source", "factor", "factor")
+
+        # 创建VertexGroup
+        vertex_group = VertexGroup(id="math_group", name="Math Operations Group")
+
+        # 添加顶点到子图
+        vertex_group.add_subgraph_vertex(add_vertex)
+        vertex_group.add_subgraph_vertex(multiply_vertex)
+
+        # 添加子图内的边
+        edge = Edge(add_vertex, multiply_vertex, Always())
+        vertex_group.add_subgraph_edge(edge)
+
+        # 暴露输出
+        vertex_group.add_exposed_output(vertex_id="multiply_vertex", variable="product", exposed_as="final_result")
+
+        return vertex_group
+
+    def test_vertex_group_with_source_and_sink(self):
+        """测试VertexGroup与SourceVertex和SinkVertex组成workflow"""
+        # 创建workflow
+        context = WorkflowContext()
+        workflow = Workflow(context)
+
+        # 创建SourceVertex
+        def source_task(inputs, context):
+            return inputs
+
+        source_vertex = SourceVertex(id="source", name="Source", task=source_task)
+
+        # 创建VertexGroup
+        vertex_group = self.create_simple_vertex_group()
+
+        # 创建SinkVertex
+        def sink_task(inputs, context):
+            return inputs
+
+        sink_vertex = SinkVertex(id="sink", name="Sink", task=sink_task)
+
+        # 添加顶点到workflow
+        workflow.add_vertex(source_vertex)
+        workflow.add_vertex(vertex_group)
+        workflow.add_vertex(sink_vertex)
+
+        # 添加边
+        workflow.add_edge(Edge(source_vertex, vertex_group, Always()))
+        workflow.add_edge(Edge(vertex_group, sink_vertex, Always()))
+
+        # 执行workflow
+        test_input = {"a": 3, "b": 5, "factor": 4}
+        workflow.execute_workflow(test_input, stream=False)
+
+        # 验证结果
+        result = workflow.result()
+        assert "sink" in result
+        assert "math_group" in result["sink"]
+        assert result["sink"]["math_group"]["final_result"] == 32  # (3+5) * 4 = 32
+
+    def test_vertex_group_with_function_vertices(self):
+        """测试VertexGroup与FunctionVertex组成workflow"""
+        # 创建workflow
+        context = WorkflowContext()
+        workflow = Workflow(context)
+
+        # 创建SourceVertex
+        def source_task(inputs, context):
+            return inputs
+
+        source_vertex = SourceVertex(id="source", name="Source", task=source_task)
+
+        # 创建前处理FunctionVertex
+        def preprocess_task(inputs):
+            logger.info(f"Preprocess task executed with inputs: {inputs}")
+            x = inputs.get("x", 0)
+            y = inputs.get("y", 0)
+            return {"a": x * 2, "b": y * 3, "factor": 2}
+
+        preprocess_vertex = FunctionVertex(id="preprocess", name="Preprocess", task=preprocess_task)
+
+        # 设置preprocess_vertex的变量依赖
+        preprocess_vertex.add_variable("source", "x", "x")
+        preprocess_vertex.add_variable("source", "y", "y")
+
+        # 创建VertexGroup
+        vertex_group = self.create_simple_vertex_group()
+        vertex_group.get_subgraph_vertex("add_vertex").add_variable("preprocess", "a", "a")
+        vertex_group.get_subgraph_vertex("add_vertex").add_variable("preprocess", "b", "b")
+        vertex_group.get_subgraph_vertex("multiply_vertex").add_variable("preprocess", "factor", "factor")
+
+        # 创建后处理FunctionVertex
+        def postprocess_task(inputs):
+            result = inputs.get("final_result", 0)
+            return {"formatted_result": f"Final answer: {result}"}
+
+        postprocess_vertex = FunctionVertex(id="postprocess", name="Postprocess", task=postprocess_task)
+
+        # 创建SinkVertex
+        def sink_task(inputs, context):
+            return inputs
+
+        sink_vertex = SinkVertex(id="sink", name="Sink", task=sink_task)
+
+        # 设置变量依赖
+        postprocess_vertex.add_variable("math_group", "final_result", "final_result")
+
+        # 添加顶点到workflow
+        workflow.add_vertex(source_vertex)
+        workflow.add_vertex(preprocess_vertex)
+        workflow.add_vertex(vertex_group)
+        workflow.add_vertex(postprocess_vertex)
+        workflow.add_vertex(sink_vertex)
+
+        # 添加边
+        workflow.add_edge(Edge(source_vertex, preprocess_vertex, Always()))
+        workflow.add_edge(Edge(preprocess_vertex, vertex_group, Always()))
+        workflow.add_edge(Edge(vertex_group, postprocess_vertex, Always()))
+        workflow.add_edge(Edge(postprocess_vertex, sink_vertex, Always()))
+
+        # 执行workflow
+        test_input = {"x": 2, "y": 3}
+        workflow.execute_workflow(test_input, stream=False)
+
+        # 验证结果
+        result = workflow.result()
+        assert "sink" in result
+        assert "postprocess" in result["sink"]
+        # preprocess: a=4, b=9, factor=2
+        # vertex_group: (4+9) * 2 = 26
+        assert result["sink"]["postprocess"]["formatted_result"] == "Final answer: 26"
+
+    def test_multiple_vertex_groups_in_workflow(self):
+        """测试多个VertexGroup在同一个workflow中"""
+        # 创建workflow
+        context = WorkflowContext()
+        workflow = Workflow(context)
+
+        # 创建SourceVertex
+        def source_task(inputs, context):
+            return inputs
+
+        source_vertex = SourceVertex(id="source", name="Source", task=source_task)
+
+        # 创建第一个VertexGroup（数学运算）
+        math_group = self.create_simple_vertex_group()
+        math_group._id = "math_group"
+
+        # 创建第二个VertexGroup（字符串处理）
+        def concat_task(inputs):
+            prefix = inputs.get("prefix", "")
+            suffix = inputs.get("suffix", "")
+            return {"text": prefix + suffix}
+
+        def format_task(inputs):
+            text = inputs.get("text", "")
+            number = inputs.get("number", 0)
+            return {"formatted": f"{text}: {number}"}
+
+        concat_vertex = FunctionVertex(id="concat_vertex", name="Concat Vertex", task=concat_task)
+
+        # 设置concat_vertex的变量依赖
+        concat_vertex.add_variable("bridge", "prefix", "prefix")
+        concat_vertex.add_variable("bridge", "suffix", "suffix")
+
+        format_vertex = FunctionVertex(id="format_vertex", name="Format Vertex", task=format_task)
+
+        # 设置format_vertex的变量依赖
+        format_vertex.add_variable("concat_vertex", "text", "text")
+        format_vertex.add_variable("bridge", "number", "number")
+
+        string_group = VertexGroup(id="string_group", name="String Processing Group")
+
+        string_group.add_subgraph_vertex(concat_vertex)
+        string_group.add_subgraph_vertex(format_vertex)
+        string_group.add_subgraph_edge(Edge(concat_vertex, format_vertex, Always()))
+        string_group.add_exposed_output(vertex_id="format_vertex", variable="formatted", exposed_as="result")
+
+        # 创建连接两个VertexGroup的FunctionVertex
+        def bridge_task(inputs):
+            math_result = inputs.get("final_result", 0)
+            return {"prefix": "Result", "suffix": " calculated", "number": math_result}
+
+        bridge_vertex = FunctionVertex(id="bridge", name="Bridge", task=bridge_task)
+
+        bridge_vertex.add_variable("math_group", "final_result", "final_result")
+
+        # 创建SinkVertex
+        def sink_task(inputs, context):
+            return inputs
+
+        sink_vertex = SinkVertex(id="sink", name="Sink", task=sink_task)
+
+        # 添加顶点到workflow
+        workflow.add_vertex(source_vertex)
+        workflow.add_vertex(math_group)
+        workflow.add_vertex(bridge_vertex)
+        workflow.add_vertex(string_group)
+        workflow.add_vertex(sink_vertex)
+
+        # 添加边
+        workflow.add_edge(Edge(source_vertex, math_group, Always()))
+        workflow.add_edge(Edge(math_group, bridge_vertex, Always()))
+        workflow.add_edge(Edge(bridge_vertex, string_group, Always()))
+        workflow.add_edge(Edge(string_group, sink_vertex, Always()))
+
+        # 执行workflow
+        test_input = {"a": 5, "b": 7, "factor": 3}
+        workflow.execute_workflow(test_input, stream=False)
+
+        # 验证结果
+        result = workflow.result()
+        assert "sink" in result
+        assert "string_group" in result["sink"]
+        # math_group: (5+7) * 3 = 36
+        # string_group: "Result calculated: 36"
+        logger.info(f"sink result {result}")
+        assert result["sink"]["string_group"]["result"] == "Result calculated: 36"
+
+    def test_vertex_group_error_handling(self):
+        """测试VertexGroup在workflow中的错误处理"""
+
+        # 创建会出错的VertexGroup
+        def error_task(inputs):
+            raise ValueError("Intentional error for testing")
+
+        error_vertex = FunctionVertex(id="error_vertex", name="Error Vertex", task=error_task)
+
+        error_group = VertexGroup(id="error_group", name="Error Group")
+
+        error_group.add_subgraph_vertex(error_vertex)
+        error_group.add_exposed_output(vertex_id="error_vertex", variable="result", exposed_as="output")
+
+        # 创建workflow
+        context = WorkflowContext()
+        workflow = Workflow(context)
+
+        # 添加SourceVertex和SinkVertex
+        def source_task(inputs, context):
+            return inputs
+
+        source_vertex = SourceVertex(id="source", name="Source", task=source_task)
+
+        def sink_task(inputs, context):
+            return inputs
+
+        sink_vertex = SinkVertex(id="sink", name="Sink", task=sink_task)
+
+        workflow.add_vertex(source_vertex)
+        workflow.add_vertex(error_group)
+        workflow.add_vertex(sink_vertex)
+
+        # 添加边
+        workflow.add_edge(Edge(source_vertex, error_group, Always()))
+        workflow.add_edge(Edge(error_group, sink_vertex, Always()))
+
+        # 执行workflow应该抛出异常
+        with pytest.raises(ValueError, match="Intentional error for testing"):
+            workflow.execute_workflow({}, stream=False)
+
+    def test_vertex_group_as_dependency(self):
+        """测试VertexGroup作为其他顶点的依赖"""
+        # 创建workflow
+        context = WorkflowContext()
+        workflow = Workflow(context)
+
+        # 创建SourceVertex
+        def source_task(inputs, context):
+            return inputs
+
+        source_vertex = SourceVertex(id="source", name="Source", task=source_task)
+
+        # 创建VertexGroup
+        vertex_group = self.create_simple_vertex_group()
+
+        # 创建依赖VertexGroup输出的FunctionVertex
+        def dependent_task(inputs):
+            group_result = inputs.get("final_result", 0)
+            return {"doubled": group_result * 2}
+
+        dependent_vertex = FunctionVertex(id="dependent", name="Dependent Vertex", task=dependent_task)
+
+        # 设置依赖关系
+        dependent_vertex.add_variable("math_group", "final_result", "final_result")
+
+        # 创建SinkVertex
+        def sink_task(inputs, context):
+            return inputs
+
+        sink_vertex = SinkVertex(id="sink", name="Sink", task=sink_task)
+
+        # 添加顶点到workflow
+        workflow.add_vertex(source_vertex)
+        workflow.add_vertex(vertex_group)
+        workflow.add_vertex(dependent_vertex)
+        workflow.add_vertex(sink_vertex)
+
+        # 添加边
+        workflow.add_edge(Edge(source_vertex, vertex_group, Always()))
+        workflow.add_edge(Edge(vertex_group, dependent_vertex, Always()))
+        workflow.add_edge(Edge(dependent_vertex, sink_vertex, Always()))
+
+        # 执行workflow
+        test_input = {"a": 4, "b": 6, "factor": 2}
+        workflow.execute_workflow(test_input, stream=False)
+
+        # 验证结果
+        result = workflow.result()
+        assert "sink" in result
+        assert "dependent" in result["sink"]
+        print(f"result: {result}")
+        # vertex_group: (4+6) * 2 = 20
+        # dependent: 20 * 2 = 40
+        assert result["sink"]["dependent"]["doubled"] == 40

--- a/vertex_flow/workflow/vertex/__init__.py
+++ b/vertex_flow/workflow/vertex/__init__.py
@@ -22,3 +22,8 @@ from .vertex import (
     SourceVertex,
     Vertex,
 )
+from .vertex_group import SubgraphContext, VertexGroup
+from .while_vertex import (
+    WhileCondition,
+    WhileVertex,
+)

--- a/vertex_flow/workflow/vertex/function_vertex.py
+++ b/vertex_flow/workflow/vertex/function_vertex.py
@@ -49,8 +49,8 @@ class FunctionVertex(Vertex[T]):
     def execute(self, inputs: Dict[str, T] = None, context: WorkflowContext[T] = None):
         if callable(self._task):
             dependencies_outputs = {dep_id: context.get_output(dep_id) for dep_id in self._dependencies}
-            all_inputs = {**dependencies_outputs, **(inputs or {})}
-
+            local_inputs = {**dependencies_outputs, **(inputs or {})}
+            all_inputs = self.resolve_dependencies(inputs=local_inputs)
             # 获取 task 函数的签名
             sig = inspect.signature(self._task)
             has_context = "context" in sig.parameters

--- a/vertex_flow/workflow/vertex/vertex.py
+++ b/vertex_flow/workflow/vertex/vertex.py
@@ -206,6 +206,10 @@ class Vertex(Generic[T], metaclass=VertexAroundMeta):
                         f"No local inputs in {self.task_type}-{self.id} to search non-scope variable {var_def}"
                     )
             else:
+                if self.workflow is None:
+                    raise ValueError(
+                        f"Vertex {self.id} has no workflow reference. Make sure the vertex is added to a workflow before resolving dependencies."
+                    )
                 source_vertex = self.workflow.get_vertice_by_id(var_def[SOURCE_SCOPE])
                 if source_vertex is None:
                     raise ValueError(f"Source Vertex {var_def[SOURCE_SCOPE]} not found.")

--- a/vertex_flow/workflow/vertex/vertex_group.py
+++ b/vertex_flow/workflow/vertex/vertex_group.py
@@ -1,0 +1,451 @@
+import logging
+import traceback
+from collections import deque
+from typing import Any, Dict, List, Optional, Set
+
+from vertex_flow.utils.logger import LoggerUtil
+from vertex_flow.workflow.constants import LOCAL_VAR, SOURCE_SCOPE, SOURCE_VAR
+from vertex_flow.workflow.edge import Edge, EdgeType
+
+from .vertex import T, Vertex, WorkflowContext
+
+logging = LoggerUtil.get_logger()
+
+
+class SubgraphContext:
+    """子图上下文，用于管理子图内部的变量和输出"""
+
+    def __init__(self, parent_context: WorkflowContext[T] = None):
+        self.parent_context = parent_context
+        self.internal_outputs = {}  # 子图内部顶点的输出
+        self.exposed_variables = {}  # 暴露给外部的变量
+
+    def store_internal_output(self, vertex_id: str, output_data: T):
+        """存储子图内部顶点的输出"""
+        self.internal_outputs[vertex_id] = output_data
+
+    def get_internal_output(self, vertex_id: str) -> T:
+        """获取子图内部顶点的输出"""
+        return self.internal_outputs.get(vertex_id, None)
+
+    def expose_variable(self, internal_vertex_id: str, variable_name: str, exposed_name: str = None):
+        """暴露子图内部变量给外部"""
+        exposed_name = exposed_name or variable_name
+        if internal_vertex_id in self.internal_outputs:
+            output = self.internal_outputs[internal_vertex_id]
+            if isinstance(output, dict) and variable_name in output:
+                self.exposed_variables[exposed_name] = output[variable_name]
+            elif variable_name is None:
+                self.exposed_variables[exposed_name] = output
+
+    def get_exposed_variables(self) -> Dict[str, Any]:
+        """获取所有暴露的变量"""
+        return self.exposed_variables.copy()
+
+
+class VertexGroup(Vertex[T]):
+    """顶点组，包含一个子图，作为一个Vertex的子图/Subgraph"""
+
+    def __init__(
+        self,
+        id: str,
+        name: str = None,
+        subgraph_vertices: List[Vertex[T]] = None,
+        subgraph_edges: List[Edge[T]] = None,
+        params: Dict[str, Any] = None,
+        variables: List[Dict[str, Any]] = None,
+    ):
+        """
+        初始化VertexGroup
+
+        Args:
+            id: 顶点组ID
+            name: 顶点组名称
+            subgraph_vertices: 子图中的顶点列表
+            subgraph_edges: 子图中的边列表
+            params: 参数字典
+            variables: 变量列表，用于定义暴露给外部的输出
+                格式: [{"source_scope": "内部顶点ID", "source_var": "变量名", "local_var": "暴露名称"}]
+        """
+        super().__init__(
+            id=id,
+            name=name,
+            task_type="VERTEX_GROUP",
+            task=self.execute_subgraph,
+            params=params,
+            variables=variables,
+        )
+
+        self.subgraph_vertices = {v.id: v for v in (subgraph_vertices or [])}
+        self.subgraph_edges = set(subgraph_edges or [])
+        self.subgraph_context = SubgraphContext()
+
+        # 为子图中的顶点设置引用
+        for vertex in self.subgraph_vertices.values():
+            vertex._vertex_group_ref = self
+            # 如果VertexGroup已经有workflow引用，则传递给子图vertex
+            if hasattr(self, "workflow") and self.workflow:
+                vertex.workflow = self.workflow
+
+        self._validate_subgraph()
+
+    @property
+    def workflow(self):
+        """获取workflow引用"""
+        return getattr(self, "_workflow", None)
+
+    @workflow.setter
+    def workflow(self, workflow):
+        """设置workflow引用，并传递给所有子图vertex"""
+        self._workflow = workflow
+        # 更新所有子图vertex的workflow引用
+        for vertex in self.subgraph_vertices.values():
+            vertex.workflow = workflow
+
+    def _validate_subgraph(self):
+        """验证子图的有效性"""
+        # 检查边的顶点是否都在子图中
+        for edge in self.subgraph_edges:
+            if (
+                edge.source_vertex.id not in self.subgraph_vertices
+                or edge.target_vertex.id not in self.subgraph_vertices
+            ):
+                raise ValueError(
+                    f"Edge {edge} contains vertices not in subgraph: "
+                    f"source={edge.source_vertex.id}, target={edge.target_vertex.id}"
+                )
+
+        # 检查variables中引用的顶点是否都在子图中
+        for var_def in self.variables:
+            source_scope = var_def.get(SOURCE_SCOPE)
+            if source_scope and source_scope not in self.subgraph_vertices:
+                raise ValueError(f"Variable source_scope '{source_scope}' not found in subgraph")
+
+    def add_subgraph_vertex(self, vertex: Vertex[T]) -> Vertex[T]:
+        """添加顶点到子图"""
+        self.subgraph_vertices[vertex.id] = vertex
+        vertex._vertex_group_ref = self
+        # 如果VertexGroup已经有workflow引用，则传递给子图vertex
+        if hasattr(self, "workflow") and self.workflow:
+            vertex.workflow = self.workflow
+
+        # 重写子图vertex的resolve_dependencies方法，使其使用vertex_group的resolve_dependencies
+        original_resolve_dependencies = vertex.resolve_dependencies
+
+        def vertex_group_resolve_dependencies(inputs=None, variables=None):
+            return self.resolve_dependencies(vertex, inputs, getattr(self, "_current_context", None))
+
+        vertex.resolve_dependencies = vertex_group_resolve_dependencies
+
+        return vertex
+
+    def add_subgraph_edge(self, edge: Edge[T]):
+        """添加边到子图"""
+        if edge.source_vertex.id not in self.subgraph_vertices or edge.target_vertex.id not in self.subgraph_vertices:
+            raise ValueError("Both vertices must be in the subgraph before adding edge")
+
+        self.subgraph_edges.add(edge)
+
+        # 更新子图内顶点的度数和依赖关系
+        target_vertex = self.subgraph_vertices[edge.target_vertex.id]
+        source_vertex = self.subgraph_vertices[edge.source_vertex.id]
+
+        target_vertex.in_degree += 1
+        target_vertex.dependencies.add(edge.source_vertex.id)
+        source_vertex.out_degree += 1
+
+    def get_subgraph_sources(self) -> List[Vertex[T]]:
+        """获取子图的源顶点（入度为0的顶点）"""
+        sources = []
+        for vertex in self.subgraph_vertices.values():
+            # 计算在子图内的实际入度
+            internal_in_degree = sum(1 for edge in self.subgraph_edges if edge.target_vertex.id == vertex.id)
+            if internal_in_degree == 0:
+                sources.append(vertex)
+        return sources
+
+    def get_subgraph_sinks(self) -> List[Vertex[T]]:
+        """获取子图的汇顶点（出度为0的顶点）"""
+        sinks = []
+        for vertex in self.subgraph_vertices.values():
+            # 计算在子图内的实际出度
+            internal_out_degree = sum(1 for edge in self.subgraph_edges if edge.source_vertex.id == vertex.id)
+            if internal_out_degree == 0:
+                sinks.append(vertex)
+        return sinks
+
+    def topological_sort_subgraph(self) -> List[Vertex[T]]:
+        """对子图进行拓扑排序"""
+        # 创建顶点的入度副本（仅考虑子图内的边）
+        in_degrees = {}
+        for vertex_id in self.subgraph_vertices:
+            in_degrees[vertex_id] = sum(1 for edge in self.subgraph_edges if edge.target_vertex.id == vertex_id)
+
+        # 获取入度为0的顶点
+        queue = deque([self.subgraph_vertices[vertex_id] for vertex_id, degree in in_degrees.items() if degree == 0])
+
+        topological_order = []
+
+        while queue:
+            vertex = queue.popleft()
+            topological_order.append(vertex)
+
+            # 减少相邻顶点的入度
+            for edge in self.subgraph_edges:
+                if edge.source_vertex.id == vertex.id:
+                    target_id = edge.target_vertex.id
+                    in_degrees[target_id] -= 1
+                    if in_degrees[target_id] == 0:
+                        queue.append(self.subgraph_vertices[target_id])
+
+        if len(topological_order) != len(self.subgraph_vertices):
+            raise ValueError(
+                f"Subgraph contains a cycle, cannot perform topological sort. "
+                f"Sorted: {len(topological_order)}, Total: {len(self.subgraph_vertices)}"
+            )
+
+        return topological_order
+
+    def resolve_subgraph_dependencies(self, vertex: Vertex[T], inputs: Dict[str, Any]) -> Dict[str, Any]:
+        """解析子图内顶点的依赖关系"""
+
+        # 如果顶点没有变量定义，直接返回原始输入
+        if not vertex.variables:
+            return inputs
+
+        resolved_values = {}
+
+        for variable in vertex.variables:
+            source_scope = variable["source_scope"]
+            source_var = variable["source_var"]
+            local_var = variable["local_var"]
+
+            if source_scope == "source":
+                # 从输入中获取变量
+                if source_var in inputs:
+                    resolved_values[local_var] = inputs[source_var]
+            else:
+                # 从子图内其他顶点的输出中获取变量
+                source_vertex = self.get_subgraph_vertex(source_scope)
+                if source_vertex and hasattr(source_vertex, "output") and source_vertex.output:
+                    if source_var in source_vertex.output:
+                        resolved_values[local_var] = source_vertex.output[source_var]
+
+        # 合并输入和解析的变量
+        final_inputs = {**inputs, **resolved_values}
+
+        return final_inputs
+
+    def resolve_dependencies(
+        self, vertex: Vertex[T], inputs: Dict[str, Any] = None, context: WorkflowContext[T] = None
+    ) -> Dict[str, Any]:
+        """解析依赖关系，支持同时访问全局context和subgraph数据，subgraph数据优先级更高"""
+
+        logging.info(f"Resolving dependencies for vertex {vertex.id}, {inputs}, {vertex.variables}")
+        # 如果顶点没有变量定义，直接返回原始输入
+        if not vertex.variables:
+            return inputs or {}
+
+        resolved_values = {}
+
+        for variable in vertex.variables:
+            source_scope = variable[SOURCE_SCOPE]
+            source_var = variable[SOURCE_VAR]
+            local_var = variable[LOCAL_VAR]
+
+            source_value = None
+
+            if source_scope == "source":
+                # 从输入中获取变量
+                if inputs and source_var in inputs:
+                    source_value = inputs[source_var]
+            if source_value is None:
+                # 优先从子图内其他顶点的输出中获取变量（subgraph数据优先级最高）
+                source_vertex = self.get_subgraph_vertex(source_scope)
+                if source_vertex and hasattr(source_vertex, "output") and source_vertex.output:
+                    if isinstance(source_vertex.output, dict) and source_var in source_vertex.output:
+                        source_value = source_vertex.output[source_var]
+                    elif source_var is None:
+                        source_value = source_vertex.output
+                elif source_vertex is None:
+                    # 如果在子图中找不到source_vertex，记录错误但继续尝试从全局获取
+                    logging.warning(f"Source vertex '{source_scope}' not found in subgraph {self.id}")
+
+                # 如果子图中没有找到，再从全局workflow中获取
+                if source_value is None and hasattr(self, "workflow") and self.workflow:
+                    try:
+                        global_vertex = self.workflow.get_vertice_by_id(source_scope)
+                        if global_vertex and hasattr(global_vertex, "output") and global_vertex.output:
+                            if isinstance(global_vertex.output, dict) and source_var in global_vertex.output:
+                                source_value = global_vertex.output[source_var]
+                            elif source_var is None:
+                                source_value = global_vertex.output
+                    except:
+                        pass
+
+                    # 如果还是没有找到，尝试直接从context的输出中获取
+                    if source_value is None and context:
+                        try:
+                            global_output = context.get_output(source_scope)
+                            if global_output:
+                                if isinstance(global_output, dict) and source_var in global_output:
+                                    source_value = global_output[source_var]
+                                elif source_var is None:
+                                    source_value = global_output
+                        except:
+                            pass
+
+            if source_value is not None:
+                resolved_values[local_var] = source_value
+
+        # 合并输入和解析的变量
+        final_inputs = {**(inputs or {}), **resolved_values}
+
+        return final_inputs
+
+    def execute_subgraph(self, inputs: Dict[str, Any] = None, context: WorkflowContext[T] = None):
+        """执行子图"""
+        logging.info(f"Starting execution of VertexGroup {self.id}")
+
+        try:
+            # 设置子图上下文
+            self.subgraph_context = SubgraphContext(context)
+            # 设置当前context供子图vertex使用
+            self._current_context = context
+
+            # 获取拓扑排序
+            execution_order = self.topological_sort_subgraph()
+            logging.info(f"Subgraph execution order: {[v.id for v in execution_order]}")
+
+            # 按拓扑顺序执行顶点
+            for vertex in execution_order:
+                logging.info(f"Executing subgraph vertex: {vertex.id}")
+
+                try:
+                    # 解析顶点的依赖关系
+                    vertex_inputs = self.resolve_dependencies(vertex, inputs or {}, context)
+
+                    # 执行顶点
+                    vertex.execute(inputs=vertex_inputs, context=context)
+
+                    # 存储输出到子图上下文
+                    if vertex.output is not None:
+                        self.subgraph_context.store_internal_output(vertex.id, vertex.output)
+
+                    # 标记为已执行
+                    vertex.is_executed = True
+
+                    logging.info(f"Subgraph vertex {vertex.id} executed successfully")
+
+                except Exception as e:
+                    logging.error(f"Error executing subgraph vertex {vertex.id}: {e}")
+                    traceback.print_exc()
+                    raise e
+
+            # 处理暴露的输出
+            self._process_exposed_outputs()
+
+            # 构建最终输出 - 直接返回暴露的变量
+            exposed_vars = self.subgraph_context.get_exposed_variables()
+
+            # 如果没有暴露的变量，返回执行摘要
+            if not exposed_vars:
+                result = {
+                    "execution_summary": {
+                        "executed_vertices": [v.id for v in execution_order],
+                        "total_vertices": len(self.subgraph_vertices),
+                        "success": True,
+                    }
+                }
+            else:
+                # 返回暴露的变量作为主要输出
+                result = exposed_vars.copy()
+
+            logging.info(f"VertexGroup {self.id} execution completed successfully")
+            return result
+
+        except Exception as e:
+            logging.error(f"Error executing VertexGroup {self.id}: {e}")
+            traceback.print_exc()
+
+            # 重新抛出异常，让上层处理
+            raise e
+
+    def _process_exposed_outputs(self):
+        """处理暴露给外部的输出"""
+        for var_def in self.variables:
+            source_scope = var_def.get(SOURCE_SCOPE)
+            source_var = var_def.get(SOURCE_VAR)
+            local_var = var_def.get(LOCAL_VAR, source_var)
+
+            if source_scope and source_scope in self.subgraph_vertices:
+                self.subgraph_context.expose_variable(source_scope, source_var, local_var)
+
+    def execute(self, inputs: Dict[str, T] = None, context: WorkflowContext[T] = None):
+        """执行VertexGroup"""
+        if self._task and callable(self._task):
+            # 获取依赖顶点的输出
+            dependencies_outputs = {}
+            if context:
+                dependencies_outputs = {dep_id: context.get_output(dep_id) for dep_id in self._dependencies}
+
+            all_inputs = {**dependencies_outputs, **(inputs or {})}
+
+            try:
+                self.output = self._task(inputs=all_inputs, context=context)
+                logging.info(f"VertexGroup {self.id} executed with output: {self.output}")
+            except Exception as e:
+                logging.error(f"Error executing VertexGroup {self.id}: {e}")
+                traceback.print_exc()
+                raise e
+        else:
+            # 执行子图
+            try:
+                self.execute_subgraph(inputs, context)
+
+                # 处理暴露输出
+                exposed_outputs = {}
+                for var_def in self.variables:
+                    source_vertex_id = var_def[SOURCE_SCOPE]
+                    source_var = var_def[SOURCE_VAR]
+                    local_var = var_def[LOCAL_VAR]
+
+                    source_vertex = self.get_subgraph_vertex(source_vertex_id)
+                    if source_vertex and hasattr(source_vertex, "output") and source_vertex.output:
+                        if source_var in source_vertex.output:
+                            exposed_outputs[local_var] = source_vertex.output[source_var]
+                        else:
+                            logging.warning(f"Variable '{source_var}' not found in vertex '{source_vertex_id}' output")
+                    else:
+                        logging.warning(f"Vertex '{source_vertex_id}' not found or has no output")
+
+                self.output = exposed_outputs
+                logging.info(f"VertexGroup {self.id} executed subgraph with exposed outputs: {self.output}")
+
+            except Exception as e:
+                logging.error(f"Error executing VertexGroup {self.id} subgraph: {e}")
+                traceback.print_exc()
+                raise e
+
+    def get_subgraph_vertex(self, vertex_id: str) -> Optional[Vertex[T]]:
+        """获取子图中的顶点"""
+        return self.subgraph_vertices.get(vertex_id)
+
+    def get_subgraph_vertices(self) -> Dict[str, Vertex[T]]:
+        """获取所有子图顶点"""
+        return self.subgraph_vertices.copy()
+
+    def get_subgraph_edges(self) -> Set[Edge[T]]:
+        """获取所有子图边"""
+        return self.subgraph_edges.copy()
+
+    def add_exposed_output(self, vertex_id: str, variable: str = None, exposed_as: str = None):
+        """添加暴露输出配置"""
+        var_def = {SOURCE_SCOPE: vertex_id, SOURCE_VAR: variable, LOCAL_VAR: exposed_as or variable}
+        self.variables.append(var_def)
+
+    def __str__(self) -> str:
+        return f"VertexGroup(id={self.id}, vertices={len(self.subgraph_vertices)}, edges={len(self.subgraph_edges)})"
+
+    def __repr__(self) -> str:
+        return self.__str__()

--- a/vertex_flow/workflow/vertex/while_vertex.py
+++ b/vertex_flow/workflow/vertex/while_vertex.py
@@ -1,0 +1,263 @@
+import inspect
+import traceback
+from typing import Any, Callable, Dict, List, Union
+
+from vertex_flow.utils.logger import LoggerUtil
+from vertex_flow.workflow.constants import SOURCE_VAR
+
+from .function_vertex import FunctionVertex
+from .vertex import T, WorkflowContext
+
+logging = LoggerUtil.get_logger()
+
+
+class WhileCondition:
+    """While循环的条件定义"""
+
+    def __init__(self, variable_selector: Dict[str, str], operator: str, value: Any, logical_operator: str = "and"):
+        """
+        初始化While条件
+
+        Args:
+            variable_selector: 变量选择器，包含SOURCE_SCOPE, SOURCE_VAR, LOCAL_VAR
+            operator: 比较操作符 (==, !=, >, <, >=, <=, contains, etc.)
+            value: 比较值
+            logical_operator: 逻辑操作符 (and, or)
+        """
+        self.variable_selector = variable_selector
+        self.operator = operator
+        self.value = value
+        self.logical_operator = logical_operator
+
+
+class WhileVertex(FunctionVertex):
+    """While循环顶点，支持条件判断和固定次数的循环控制"""
+
+    def __init__(
+        self,
+        id: str,
+        name: str = None,
+        execute_task: Callable[[Dict[str, Any], WorkflowContext[T]], Any] = None,
+        condition_task: Callable[[Dict[str, Any], WorkflowContext[T]], bool] = None,
+        conditions: List[WhileCondition] = None,
+        logical_operator: str = "and",
+        max_iterations: int = None,
+        params: Dict[str, Any] = None,
+        variables: List[Dict[str, Any]] = None,
+    ):
+        """
+        初始化WhileVertex
+
+        Args:
+            id: 顶点ID
+            name: 顶点名称
+            execute_task: 循环体执行逻辑的函数
+            condition_task: 条件判断逻辑的函数（可选，与conditions二选一）
+            conditions: 条件列表（可选，与condition_task二选一）
+            logical_operator: 多个条件之间的逻辑操作符
+            max_iterations: 最大迭代次数（可选）
+            params: 参数字典
+            variables: 变量列表
+        """
+        # 设置默认的task为while_loop方法
+        task = self.while_loop
+
+        super().__init__(
+            id=id,
+            name=name,
+            task=task,
+            params={
+                **(params or {}),
+                **{FunctionVertex.SubTypeKey: self.__class__.__name__},
+            },
+            variables=variables,
+        )
+
+        if not execute_task:
+            raise ValueError("execute_task is required for WhileVertex")
+
+        if not condition_task and not conditions:
+            raise ValueError("Either condition_task or conditions must be provided")
+
+        if condition_task and conditions:
+            raise ValueError("Cannot provide both condition_task and conditions")
+
+        self.execute_task = execute_task
+        self.condition_task = condition_task
+        self.conditions = conditions or []
+        self.logical_operator = logical_operator
+        self.max_iterations = max_iterations
+        self._validate_conditions()
+
+    def _validate_conditions(self):
+        """验证条件的有效性"""
+        if self.logical_operator not in ["and", "or"]:
+            raise ValueError(
+                f"Unsupported logical operator: {self.logical_operator}. " f"Supported operators are 'and' and 'or'."
+            )
+
+    def evaluate_condition(self, condition: WhileCondition, inputs: Dict[str, Any]) -> bool:
+        """
+        评估单个条件
+
+        Args:
+            condition: WhileCondition实例
+            inputs: 输入数据
+
+        Returns:
+            bool: 条件评估结果
+        """
+        variable_selector = condition.variable_selector
+        value = condition.value
+        operator = condition.operator
+        variable_name = variable_selector[SOURCE_VAR]
+
+        # 获取变量值
+        variable_value = self.resolve_dependencies(variable_selector=variable_selector, inputs=inputs).get(
+            variable_name
+        )
+
+        # 检查变量是否存在
+        if variable_value is None:
+            raise ValueError(f"Variable '{variable_name}' not found in context.")
+
+        # 操作符映射
+        operators = {
+            "==": lambda v: str(variable_value) == str(v),
+            "is": lambda v: str(variable_value) == str(v),
+            "!=": lambda v: str(variable_value) != str(v),
+            ">": lambda v: float(variable_value) > float(v),
+            "<": lambda v: float(variable_value) < float(v),
+            ">=": lambda v: float(variable_value) >= float(v),
+            "<=": lambda v: float(variable_value) <= float(v),
+            "contains": lambda v: str(v) in str(variable_value),
+            "not_contains": lambda v: str(v) not in str(variable_value),
+            "starts_with": lambda v: str(variable_value).startswith(str(v)),
+            "ends_with": lambda v: str(variable_value).endswith(str(v)),
+            "is_empty": lambda v: not variable_value,
+            "is_not_empty": lambda v: bool(variable_value),
+        }
+
+        # 获取操作符对应的函数
+        operation = operators.get(operator)
+        if not operation:
+            raise ValueError(f"Unsupported operator: {operator}")
+
+        # 执行操作
+        try:
+            return operation(value)
+        except (ValueError, TypeError) as e:
+            logging.warning(f"Error evaluating condition: {e}")
+            return False
+
+    def evaluate_conditions(self, inputs: Dict[str, Any]) -> bool:
+        """
+        评估所有条件
+
+        Args:
+            inputs: 输入数据
+
+        Returns:
+            bool: 组合条件的评估结果
+        """
+        if not self.conditions:
+            return True
+
+        results = [self.evaluate_condition(condition, inputs) for condition in self.conditions]
+
+        if self.logical_operator == "and":
+            return all(results)
+        elif self.logical_operator == "or":
+            return any(results)
+        else:
+            raise ValueError(f"Unsupported logical operator: {self.logical_operator}")
+
+    def should_continue(self, inputs: Dict[str, Any], context: WorkflowContext[T]) -> bool:
+        """
+        判断是否应该继续循环
+
+        Args:
+            inputs: 输入数据
+            context: 工作流上下文
+
+        Returns:
+            bool: 是否继续循环
+        """
+        if self.condition_task:
+            # 使用自定义条件函数
+            sig = inspect.signature(self.condition_task)
+            has_context = "context" in sig.parameters
+
+            try:
+                if has_context:
+                    return self.condition_task(inputs=inputs, context=context)
+                else:
+                    return self.condition_task(inputs=inputs)
+            except Exception as e:
+                logging.warning(f"Error evaluating condition_task: {e}")
+                return False
+        else:
+            # 使用条件列表
+            return self.evaluate_conditions(inputs)
+
+    def while_loop(self, inputs: Dict[str, Any] = None, context: WorkflowContext[T] = None):
+        """
+        While循环的主要逻辑
+
+        Args:
+            inputs: 输入数据
+            context: 工作流上下文
+
+        Returns:
+            循环执行的结果
+        """
+        iteration_count = 0
+        results = []
+        current_inputs = inputs.copy() if inputs else {}
+
+        logging.info(f"Starting while loop in vertex {self.id}")
+
+        try:
+            while True:
+                # 检查最大迭代次数
+                if self.max_iterations is not None and iteration_count >= self.max_iterations:
+                    logging.info(f"Reached max iterations ({self.max_iterations}) in vertex {self.id}")
+                    break
+
+                # 检查循环条件
+                if not self.should_continue(current_inputs, context):
+                    logging.info(f"Loop condition failed in vertex {self.id} at iteration {iteration_count}")
+                    break
+
+                # 执行循环体
+                sig = inspect.signature(self.execute_task)
+                has_context = "context" in sig.parameters
+
+                try:
+                    if has_context:
+                        result = self.execute_task(inputs=current_inputs, context=context)
+                    else:
+                        result = self.execute_task(inputs=current_inputs)
+
+                    results.append(result)
+
+                    # 更新输入数据（如果结果是字典，则合并到输入中）
+                    if isinstance(result, dict):
+                        current_inputs.update(result)
+
+                    iteration_count += 1
+                    logging.debug(f"Completed iteration {iteration_count} in vertex {self.id}")
+
+                except Exception as e:
+                    logging.error(f"Error in execute_task at iteration {iteration_count}: {e}")
+                    traceback.print_exc()
+                    break
+
+        except Exception as e:
+            logging.error(f"Error in while loop: {e}")
+            traceback.print_exc()
+            raise e
+
+        logging.info(f"While loop completed in vertex {self.id} after {iteration_count} iterations")
+
+        return {"results": results, "iteration_count": iteration_count, "final_inputs": current_inputs}


### PR DESCRIPTION
resolve VertexGroup workflow reference and dependency resolution issues

- Fix VertexGroup execute method to handle subgraph execution when no task is provided
- Add workflow reference propagation to subgraph vertices in add_subgraph_vertex
- Override resolve_dependencies method for subgraph vertices to use VertexGroup's dependency resolution
- Add exposed output handling in VertexGroup execution
- Fix incorrect vertex ID references in test cases (vertex_group -> math_group)
- Add workflow setter to automatically propagate workflow reference to all subgraph vertices

This resolves KeyError issues when VertexGroup is used as a dependency in workflows
and ensures proper dependency resolution within subgraphs.